### PR TITLE
Add OLM catalog generation infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Binaries
+/bin/
+
+# Generated files
+/auto-generated/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM quay.io/operator-framework/opm:v1.54.0
+
+ARG INDEX_FILE=./auto-generated/catalog/dev.yaml
+COPY $INDEX_FILE /configs/bpfman-operator/index.yaml
+
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Indicate where the catalog configuration is located in the image.
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/Dockerfile.generate
+++ b/Dockerfile.generate
@@ -1,0 +1,30 @@
+# Use alpine for the build stage with shell support.
+FROM alpine:latest AS builder
+
+# Install OPM from the official image.
+COPY --from=quay.io/operator-framework/opm:v1.54.0 /bin/opm /bin/opm
+
+# Create containers policy configuration. Use standard development policy
+# that matches Fedora's default configuration.
+RUN mkdir -p /etc/containers && \
+    echo '{"default":[{"type":"insecureAcceptAnything"}],"transports":{"docker-daemon":{"":[{"type":"insecureAcceptAnything"}]}}}' > /etc/containers/policy.json
+
+ARG TEMPLATE_FILE
+
+WORKDIR /workspace
+
+COPY templates/${TEMPLATE_FILE} ./template.yaml
+
+# Generate catalog for single template. Use symlink to make BuildKit
+# mount accessible to OPM. This allows OPM to read credentials without
+# copying them to the filesystem.
+RUN --mount=type=secret,id=dockerconfig,target=/run/secrets/auth.json \
+    mkdir -p /root/.docker && \
+    ln -s /run/secrets/auth.json /root/.docker/config.json && \
+    /bin/opm alpha render-template basic \
+        --migrate-level=bundle-object-to-csv-metadata \
+        -o yaml ./template.yaml > catalog.yaml && \
+    rm -f /root/.docker/config.json
+
+FROM scratch
+COPY --from=builder /workspace/catalog.yaml /catalog.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,132 @@
+.DEFAULT_GOAL := all
+
+IMAGE ?= quay.io/$(USER)/bpfman-operator-catalog:latest
+BUILD_STREAM ?= dev
+
+# Image building tool - podman only for catalog generation
+OCI_BIN_PATH := $(shell which podman)
+OCI_BIN ?= $(shell basename ${OCI_BIN_PATH})
+export OCI_BIN
+
+LOCALBIN ?= $(shell pwd)/bin
+
+# OPM configuration - v1.52 for local install (v1.54 has go.mod replace issues)
+OPM_VERSION := v1.52.0
+OPM_IMAGE := quay.io/operator-framework/opm:$(OPM_VERSION)
+YQ_VERSION  := v4.35.2
+
+OPM ?= $(LOCALBIN)/opm
+YQ  ?= $(LOCALBIN)/yq
+
+# Define go-install macro for installing Go tools.
+# $1 = tool binary path
+# $2 = tool package
+# $3 = tool version
+define go-install
+	@[ -f $(1) ] || { \
+		echo "Downloading $(notdir $(1)) $(3)..." ; \
+		GOBIN=$(LOCALBIN) go install $(2)@$(3) ; \
+	}
+endef
+
+.PHONY: opm
+opm: $(OPM) ## Download opm locally if necessary.
+$(OPM):
+	$(call go-install,$(OPM),github.com/operator-framework/operator-registry/cmd/opm,$(OPM_VERSION))
+
+.PHONY: yq
+yq: $(YQ) ## Download yq locally if necessary.
+$(YQ):
+	$(call go-install,$(YQ),github.com/mikefarah/yq/v4,$(YQ_VERSION))
+
+.PHONY: prereqs
+prereqs: opm yq
+
+# Template files
+TEMPLATES := $(wildcard templates/*.yaml)
+CATALOGS := $(patsubst templates/%.yaml,auto-generated/catalog/%.yaml,$(TEMPLATES))
+
+auto-generated/catalog:
+	mkdir -p $@
+
+##@ Build
+
+.PHONY: generate-catalogs
+generate-catalogs: prereqs ## Generate catalogs from templates using local OPM.
+	@for template in $(TEMPLATES); do \
+		catalog="auto-generated/catalog/$$(basename $$template)" ; \
+		echo "Generating $$catalog (local)..." ; \
+		$(OPM) alpha render-template basic --migrate-level=bundle-object-to-csv-metadata -o yaml $$template > $$catalog ; \
+	done
+
+.PHONY: generate-catalogs-container
+generate-catalogs-container: | auto-generated/catalog ## Generate catalogs using OPM container (requires Podman auth).
+	@if [ -z "$(OCI_BIN_PATH)" ]; then \
+		echo "ERROR: Podman is required but not found in PATH" ; \
+		echo "Please install podman first" ; \
+		exit 1 ; \
+	fi
+	@if [ ! -f "$${XDG_RUNTIME_DIR}/containers/auth.json" ]; then \
+		echo "ERROR: No Podman registry authentication found." ; \
+		echo "Please login to registry first:" ; \
+		echo "  podman login registry.redhat.io" ; \
+		exit 1 ; \
+	fi
+	@echo "Generating catalogs using container approach..."
+	@for template in $(TEMPLATES); do \
+		template_name=$$(basename $$template) ; \
+		catalog="auto-generated/catalog/$$template_name" ; \
+		echo "Processing $$template_name..." ; \
+		$(OCI_BIN) build --quiet \
+			--secret id=dockerconfig,src=$${XDG_RUNTIME_DIR}/containers/auth.json \
+			--build-arg TEMPLATE_FILE=$$template_name \
+			-f Dockerfile.generate -t temp-catalog:$$template_name . && \
+		$(OCI_BIN) create --name temp-$$template_name temp-catalog:$$template_name >/dev/null && \
+		$(OCI_BIN) cp temp-$$template_name:/catalog.yaml $$catalog && \
+		$(OCI_BIN) rm temp-$$template_name >/dev/null && \
+		$(OCI_BIN) rmi temp-catalog:$$template_name >/dev/null || exit 1 ; \
+	done
+	@echo "Catalogs generated successfully"
+
+.PHONY: build-image
+build-image: ## Build catalog container image.
+	$(OCI_BIN) build --build-arg INDEX_FILE="./auto-generated/catalog/$(BUILD_STREAM).yaml" -t $(IMAGE) -f Dockerfile .
+
+.PHONY: push-image
+push-image: ## Push catalog container image.
+	$(OCI_BIN) push ${IMAGE}
+
+##@ Deployment
+
+.PHONY: deploy
+deploy: yq ## Deploy catalog to OpenShift cluster.
+	$(YQ) '.spec.image="$(IMAGE)"' ./catalog-source.yaml | kubectl apply -f -
+
+.PHONY: undeploy
+undeploy: ## Remove catalog from OpenShift cluster.
+	kubectl delete -f ./catalog-source.yaml
+
+##@ Cleanup
+
+.PHONY: clean-generated-catalogs
+clean-generated-catalogs: ## Remove generated catalogs.
+	rm -rf auto-generated/catalog/*.yaml
+
+.PHONY: clean-tools
+clean-tools: ## Remove downloaded tools.
+	rm -rf $(LOCALBIN)
+
+.PHONY: clean
+clean: clean-generated-catalogs clean-tools ## Remove all generated files and tools.
+
+##@ General
+
+.PHONY: all
+all: help ## Default target: display help.
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make <target>\n\n"} \
+		/^[a-zA-Z_0-9-]+:.*?##/ { printf "  %-25s %s\n", $$1, $$2 } \
+		/^##@/ { printf "\n%s\n", substr($$0, 5) }' \
+		$(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,105 @@
 # bpfman-catalog
-OLM catalog used to release the Openshift eBPF Manager Operator
+
+OLM catalog used to release the Openshift eBPF Manager Operator.
+
+## Overview
+
+This repository builds the BPFMan OLM catalog used to release new versions of the OpenShift eBPF Manager Operator. It generates operator catalogs from templates and packages them as OCI images for deployment to OpenShift clusters.
+
+## Directory Structure
+
+- `templates/` - Source YAML files defining operator versions and channels
+  - `dev.yaml` - Development builds from Konflux CI (default)
+  - `y-stream.yaml` - Y-stream minor version releases
+  - `z-stream.yaml` - Z-stream patch releases
+- `auto-generated/` - Generated catalogs (created by `make generate-catalogs`)
+  - `catalog/` - Modern catalog format with bundle-object-to-csv-metadata migration
+- `Dockerfile` - Container definition for building catalog images
+- `catalog-source.yaml` - CatalogSource resource for deploying to OpenShift
+
+## Common Commands
+
+Run `make` to list all available targets.
+
+### Generate Catalogs
+
+Generate catalogs from templates:
+```bash
+make generate-catalogs
+```
+
+### Build Container Image
+
+Build catalog image (defaults to dev):
+```bash
+make build-image
+```
+
+Build with y-stream releases:
+```bash
+make build-image BUILD_STREAM=y-stream
+```
+
+Build with custom image tag:
+```bash
+make build-image IMAGE=quay.io/myuser/bpfman-catalog:latest
+```
+
+### Deploy to Cluster
+
+Deploy catalog to OpenShift cluster:
+```bash
+make build-image push-image deploy
+```
+
+Individual steps:
+```bash
+make push-image    # Push built image
+make deploy        # Deploy catalog source to cluster
+make undeploy      # Remove catalog source from cluster
+```
+
+## Development Workflow
+
+1. Modify template files in `templates/` directory
+2. Run `make generate-catalogs` to update auto-generated catalogs
+3. Build and test with `make build-image`
+4. Push image with `make push-image`
+5. Deploy to test cluster with `make deploy`
+
+## Configuration Variables
+
+- `IMAGE` - Target image name (default: quay.io/$USER/bpfman-operator-catalog:latest)
+- `BUILD_STREAM` - Which template to use (default: dev, options: dev, y-stream, z-stream)
+- `OCI_BIN` - Container runtime (docker or podman, auto-detected)
+
+## Development vs Release Workflows
+
+### For Daily Development
+Use the default `dev` template which points to your latest CI builds from Konflux:
+```bash
+# Update templates/dev.yaml with your latest bundle SHA from Konflux
+$EDITOR templates/dev.yaml
+make generate-catalogs
+make build-image
+make push-image
+make deploy
+```
+
+### For Y-Stream Releases
+Use the `y-stream` template for minor version releases:
+```bash
+make generate-catalogs
+make build-image BUILD_STREAM=y-stream
+make push-image BUILD_STREAM=y-stream
+make deploy BUILD_STREAM=y-stream
+```
+
+### For Z-Stream Releases
+Use the `z-stream` template for patch releases:
+```bash
+make generate-catalogs
+make build-image BUILD_STREAM=z-stream
+make push-image BUILD_STREAM=z-stream
+make deploy BUILD_STREAM=z-stream
+```

--- a/auto-generated/catalog/y-stream.yaml
+++ b/auto-generated/catalog/y-stream.yaml
@@ -1,0 +1,1152 @@
+---
+defaultChannel: stable
+name: bpfman-operator
+schema: olm.package
+---
+entries:
+- name: bpfman-operator.v0.5.7-dev
+name: stable
+package: bpfman-operator
+schema: olm.channel
+---
+image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:36922ea0b333bf60bfd358425681c472db07a99dd07c929383ee3bcc5e93c19f
+name: bpfman-operator.v0.5.7-dev
+package: bpfman-operator
+properties:
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: BpfApplication
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: BpfApplicationState
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: ClusterBpfApplication
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: ClusterBpfApplicationState
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bpfman-operator
+    version: 0.5.7-dev
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "BpfApplication",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/name": "bpfapplication"
+              },
+              "name": "bpfapplication-sample",
+              "namespace": "acme"
+            },
+            "spec": {
+              "byteCode": {
+                "image": {
+                  "url": "quay.io/bpfman-bytecode/app-test:latest"
+                }
+              },
+              "globalData": {
+                "GLOBAL_u32": [
+                  13,
+                  12,
+                  11,
+                  10
+                ],
+                "GLOBAL_u8": [
+                  1
+                ]
+              },
+              "nodeSelector": {},
+              "programs": [
+                {
+                  "name": "tc_pass_test",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 55
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "BpfApplicationState",
+            "metadata": {
+              "creationTimestamp": "2025-04-30T20:59:17Z",
+              "finalizers": [
+                "bpfman.io.nsbpfapplicationcontroller/finalizer"
+              ],
+              "generation": 1,
+              "labels": {
+                "bpfman.io/ownedByProgram": "bpfapplication-sample",
+                "kubernetes.io/hostname": "bpfman-deployment-control-plane"
+              },
+              "name": "bpfapplication-sample-ed7beed4",
+              "namespace": "acme",
+              "ownerReferences": [
+                {
+                  "apiVersion": "bpfman.io/v1alpha1",
+                  "blockOwnerDeletion": true,
+                  "controller": true,
+                  "kind": "BpfApplication",
+                  "name": "bpfapplication-sample",
+                  "uid": "a3897014-2014-4585-90a1-ccdb70adeef9"
+                }
+              ],
+              "resourceVersion": "1348",
+              "uid": "5728d3b2-a576-4144-be74-e5c83619344e"
+            },
+            "status": {
+              "appLoadStatus": "LoadSuccess",
+              "conditions": [
+                {
+                  "lastTransitionTime": "2025-04-30T21:01:50Z",
+                  "message": "The BPF application has been successfully loaded and attached",
+                  "reason": "Success",
+                  "status": "True",
+                  "type": "Success"
+                }
+              ],
+              "node": "bpfman-deployment-control-plane",
+              "programs": [
+                {
+                  "name": "tc_pass_test",
+                  "programId": 1398,
+                  "programLinkStatus": "Success",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1909324080,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "38e00746-b7be-4bcf-bf14-622ad349b4fa"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1342701196,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "ba806cdf-5980-4e7f-8d8f-d819e6a57220"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 2698014225,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "e74fa413-d5df-4aa8-8d17-b580b6cb42a5"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 184300305,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "cef8985d-f184-4b18-9ee2-fe21018fae77"
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "programId": 1399,
+                  "programLinkStatus": "Success",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 1256673356,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "3feed40b-fe4b-4a69-8e91-49624df45673"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 18009714,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "37b02539-0884-418d-bee4-31456384495e"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 3446068106,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "24a56373-8967-46f4-bbd4-423a7872f18b"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 733646956,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "4c855178-0a35-4ac6-abf7-83e61541aca4"
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "programId": 1400,
+                  "programLinkStatus": "Success",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containerPid": 3041,
+                        "function": "malloc",
+                        "linkId": 3629930733,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "ed72f8a7-cdc9-4245-8c40-c645fa5969d7"
+                      },
+                      {
+                        "containerPid": 3032,
+                        "function": "malloc",
+                        "linkId": 1860984127,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "5c3b196d-bbe9-4b2c-8c5c-9d78c5ed6512"
+                      },
+                      {
+                        "containerPid": 2792,
+                        "function": "malloc",
+                        "linkId": 3256920823,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "927071d2-c574-4c1f-87f2-baa5e7cfcc8f"
+                      },
+                      {
+                        "containerPid": 2833,
+                        "function": "malloc",
+                        "linkId": 3700254381,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "fd351a1a-fb83-4b6c-af2f-c84906c6b54b"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "programId": 1401,
+                  "programLinkStatus": "Success",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containerPid": 3041,
+                        "function": "malloc",
+                        "linkId": 4161687115,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "2c8ad027-eca0-4da9-baa6-f7b6f0fc25fd"
+                      },
+                      {
+                        "containerPid": 3032,
+                        "function": "malloc",
+                        "linkId": 3445215503,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "623f2642-9f85-45ca-bab4-8f98d8a31079"
+                      },
+                      {
+                        "containerPid": 2792,
+                        "function": "malloc",
+                        "linkId": 1387817990,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "fe81f29b-493d-41a9-b1c7-35733c9ee861"
+                      },
+                      {
+                        "containerPid": 2833,
+                        "function": "malloc",
+                        "linkId": 2271422622,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "d6af1106-2c72-4f7d-9ee9-5c32e59e03b7"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "programId": 1402,
+                  "programLinkStatus": "Success",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1752219747,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "17760ccc-5ca7-4d21-9590-5f6e5c0fd4ab"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 3877814802,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "194d2096-a15f-417f-9be6-2032217f3e86"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 2514284800,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "de0f43b3-6a0e-4c22-8127-9fb519a0238b"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1682543086,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "84289766-bff1-4af5-a0bd-5d150747a29a"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "updateCount": 2
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "ClusterBpfApplication",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/name": "clusterbpfapplication"
+              },
+              "name": "clusterbpfapplication-sample"
+            },
+            "spec": {
+              "byteCode": {
+                "image": {
+                  "url": "quay.io/bpfman-bytecode/app-test:latest"
+                }
+              },
+              "globalData": {
+                "GLOBAL_u32": [
+                  13,
+                  12,
+                  11,
+                  10
+                ],
+                "GLOBAL_u8": [
+                  1
+                ]
+              },
+              "nodeSelector": {},
+              "programs": [
+                {
+                  "kprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "offset": 0
+                      }
+                    ]
+                  },
+                  "name": "kprobe_test",
+                  "type": "KProbe"
+                },
+                {
+                  "kretprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up"
+                      }
+                    ]
+                  },
+                  "name": "kretprobe_test",
+                  "type": "KRetProbe"
+                },
+                {
+                  "name": "tracepoint_test",
+                  "tracepoint": {
+                    "links": [
+                      {
+                        "name": "syscalls/sys_enter_openat"
+                      }
+                    ]
+                  },
+                  "type": "TracePoint"
+                },
+                {
+                  "name": "tc_pass_test",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 55
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 500
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "containerNames": [
+                            "bpfman",
+                            "bpfman-agent"
+                          ],
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "containerNames": [
+                            "bpfman",
+                            "bpfman-agent"
+                          ],
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 55
+                      },
+                      {
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  }
+                },
+                {
+                  "fentry": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "mode": "Attach"
+                      }
+                    ]
+                  },
+                  "name": "fentry_test",
+                  "type": "FEntry"
+                },
+                {
+                  "fexit": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "mode": "Attach"
+                      }
+                    ]
+                  },
+                  "name": "fexit_test",
+                  "type": "FExit"
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "ClusterBpfApplicationState",
+            "metadata": {
+              "creationTimestamp": "2025-04-30T20:58:34Z",
+              "finalizers": [
+                "bpfman.io.clbpfapplicationcontroller/finalizer"
+              ],
+              "generation": 1,
+              "labels": {
+                "bpfman.io/ownedByProgram": "clusterbpfapplication-sample",
+                "kubernetes.io/hostname": "bpfman-deployment-control-plane"
+              },
+              "name": "clusterbpfapplication-sample-d3cc4fee",
+              "ownerReferences": [
+                {
+                  "apiVersion": "bpfman.io/v1alpha1",
+                  "blockOwnerDeletion": true,
+                  "controller": true,
+                  "kind": "ClusterBpfApplication",
+                  "name": "clusterbpfapplication-sample",
+                  "uid": "ab16b9a6-16bd-4a22-98ec-4268efaf8c8d"
+                }
+              ],
+              "resourceVersion": "1176",
+              "uid": "6e7e7446-306f-46ae-98e6-6ff28d9b5bcd"
+            },
+            "status": {
+              "appLoadStatus": "LoadSuccess",
+              "conditions": [
+                {
+                  "lastTransitionTime": "2025-04-30T21:00:16Z",
+                  "message": "The BPF application has been successfully loaded and attached",
+                  "reason": "Success",
+                  "status": "True",
+                  "type": "Success"
+                }
+              ],
+              "node": "bpfman-deployment-control-plane",
+              "programs": [
+                {
+                  "kprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "linkId": 818584239,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "uuid": "3c71185f-8d68-4be8-92cb-32a14a6f118b"
+                      }
+                    ]
+                  },
+                  "name": "kprobe_test",
+                  "programId": 1323,
+                  "programLinkStatus": "Success",
+                  "type": "KProbe"
+                },
+                {
+                  "kretprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "linkId": 3409359936,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "44c75019-f175-4b1e-bb34-d8896e3b0456"
+                      }
+                    ]
+                  },
+                  "name": "kretprobe_test",
+                  "programId": 1324,
+                  "programLinkStatus": "Success",
+                  "type": "KRetProbe"
+                },
+                {
+                  "name": "tracepoint_test",
+                  "programId": 1325,
+                  "programLinkStatus": "Success",
+                  "tracepoint": {
+                    "links": [
+                      {
+                        "linkId": 2625161294,
+                        "linkStatus": "Attached",
+                        "name": "syscalls/sys_enter_openat",
+                        "shouldAttach": true,
+                        "uuid": "40164d8a-5b55-4ff6-8e73-aa53d9180a6d"
+                      }
+                    ]
+                  },
+                  "type": "TracePoint"
+                },
+                {
+                  "name": "tc_pass_test",
+                  "programId": 1327,
+                  "programLinkStatus": "Success",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1304307969,
+                        "linkStatus": "Attached",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "44e6491e-ca98-44a0-b1b7-647b494c84fa"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 1425071644,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "89a05d8f-bb4a-448a-af11-2605d0094b98"
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "programId": 1328,
+                  "programLinkStatus": "Success",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 858546813,
+                        "linkStatus": "Attached",
+                        "priority": 500,
+                        "shouldAttach": true,
+                        "uuid": "6dff4163-4d62-4c93-bc34-739a796ddbb4"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 5042726,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "c066df6a-667e-4382-9e2f-a59f64bc1b7e"
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "programId": 1329,
+                  "programLinkStatus": "Success",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containerPid": 2089,
+                        "function": "malloc",
+                        "linkId": 2687038538,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "e48f1563-f56b-41fa-a87d-b8593fc5faca"
+                      },
+                      {
+                        "containerPid": 2040,
+                        "function": "malloc",
+                        "linkId": 1651822558,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "e0d778df-4791-413b-b0f4-13ed1088500c"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "programId": 1330,
+                  "programLinkStatus": "Success",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containerPid": 2089,
+                        "function": "malloc",
+                        "linkId": 3774838420,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "2f37f466-6ff4-47a1-9c8d-8dd1f97528bb"
+                      },
+                      {
+                        "containerPid": 2040,
+                        "function": "malloc",
+                        "linkId": 1373645282,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "319bbaf0-1c8a-45b4-9d99-5dec27e2e5f1"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "programId": 1332,
+                  "programLinkStatus": "Success",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 4243141192,
+                        "linkStatus": "Attached",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "c3bea5b9-d3e0-4784-9a17-c286b6661fc2"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1465833891,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "1e24df86-f3ff-4e0a-8f20-6759272ddb08"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "fentry": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "linkId": 950386839,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "2eda2367-4540-478b-a40d-cc984475a570"
+                      }
+                    ]
+                  },
+                  "name": "fentry_test",
+                  "programId": 1333,
+                  "programLinkStatus": "Success",
+                  "type": "FEntry"
+                },
+                {
+                  "fexit": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "linkId": 2243237521,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "98910fe0-cad6-457f-8797-9f8200106511"
+                      }
+                    ]
+                  },
+                  "name": "fexit_test",
+                  "programId": 1334,
+                  "programLinkStatus": "Success",
+                  "type": "FExit"
+                }
+              ],
+              "updateCount": 2
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: OpenShift Optional
+      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:7a3c4e3bf315ee004833cbbd4e8847b5520afb056fecbe8019528d1f7ef4abf8
+      createdAt: 04 Aug 2025, 08:10
+      description: The eBPF manager Operator is designed to manage eBPF programs for
+        applications.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "true"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: bpfman
+      operatorframework.io/suggested-namespace-template: |-
+        {
+          "apiVersion": "v1",
+          "kind": "Namespace",
+          "metadata": {
+            "name": "bpfman",
+            "labels": {
+              "pod-security.kubernetes.io/enforce": "privileged",
+              "pod-security.kubernetes.io/audit": "privileged",
+              "pod-security.kubernetes.io/warn": "privileged",
+            },
+            "annotations": {
+              "openshift.io/node-selector": ""
+            },
+          }
+        }
+      operators.openshift.io/infrastructure-features: '["csi", "disconnected"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.27.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/bpfman/bpfman
+      support: bpfman Community
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: BpfApplication is the Schema for the BpfApplications API
+        displayName: Namespaced Bpf Application
+        kind: BpfApplication
+        name: bpfapplications.bpfman.io
+        version: v1alpha1
+      - description: BpfApplicationState is the Schema for the BpfApplicationState
+          API
+        displayName: Namespaced Bpf Application State
+        kind: BpfApplicationState
+        name: bpfapplicationstates.bpfman.io
+        version: v1alpha1
+      - description: ClusterBpfApplication is the Schema for the clusterbpfapplications
+          API
+        displayName: Cluster Bpf Application
+        kind: ClusterBpfApplication
+        name: clusterbpfapplications.bpfman.io
+        version: v1alpha1
+      - description: ClusterBpfApplicationState is the Schema for the ClusterBpfApplicationState
+          API
+        displayName: Cluster Bpf Application State
+        kind: ClusterBpfApplicationState
+        name: clusterbpfapplicationstates.bpfman.io
+        version: v1alpha1
+    description: "The eBPF manager Operator is a Kubernetes Operator for deploying
+      [bpfman](https://bpfman.netlify.app/), a system daemon\nfor managing eBPF programs.
+      It deploys bpfman itself along with CRDs to make deploying\neBPF programs in
+      Kubernetes much easier.\n\n## Quick Start\n \nTo get bpfman up and running quickly
+      simply click 'install' to deploy the bpfman-operator in the bpfman namespace
+      via operator-hub.\n## Configuration\n\nThe `bpfman-config` configmap is automatically
+      created in the `bpfman` namespace and used to configure the bpfman deployment.\n\nTo
+      edit the config simply run\n\n```bash\nkubectl edit cm bpfman-config\n```\n\nThe
+      following fields are adjustable\n\n- `bpfman.agent.image`: The image used for
+      the bpfman-agent`\n- `bpfman.image`: The image used for bpfman`\n - `bpfman.log.level`:
+      the log level for bpfman, currently supports `debug`, `info`, `warn`, `error`,
+      and `fatal`, defaults to `info`\n- `bpfman.agent.log.level`: the log level for
+      the bpfman-agent currently supports `info`, `debug`, and `trace` \n\nThe bpfman
+      operator deploys eBPF programs via CRDs. The following CRDs are currently available,
+      \n\n- BpfApplication\n- ClusterBpfApplication\n - BpfApplicationState\n - ClusterBpfApplicationState\n\n
+      ## More information\n\nPlease checkout the [bpfman community website](https://bpfman.io/)
+      for more information."
+    displayName: eBPF Manager Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - ebpf
+    - kubernetes
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: bpfman website
+      url: https://www.redhat.com/
+    maintainers:
+    - email: afredette@redhat.com
+      name: Andre Fredette
+    - email: mmahmoud@redhat.com
+      name: Mohamed Mahmoud
+    maturity: alpha
+    minKubeVersion: 1.26.0
+    provider:
+      name: Red Hat
+      url: https://www.redhat.com/
+relatedImages:
+- image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:36922ea0b333bf60bfd358425681c472db07a99dd07c929383ee3bcc5e93c19f
+  name: ""
+- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:7a3c4e3bf315ee004833cbbd4e8847b5520afb056fecbe8019528d1f7ef4abf8
+  name: ""
+schema: olm.bundle

--- a/catalog-source.yaml
+++ b/catalog-source.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: bpfman-dev-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/bpfman/bpfman-operator-catalog:latest
+  displayName: BPFMan development catalog
+  publisher: Me
+  updateStrategy:
+    registryPoll:
+      interval: 1m

--- a/templates/dev.yaml
+++ b/templates/dev.yaml
@@ -1,0 +1,16 @@
+schema: olm.template.basic
+entries:
+  - schema: olm.package
+    name: bpfman-operator
+    defaultChannel: preview
+  - schema: olm.channel
+    package: bpfman-operator
+    name: preview
+    entries:
+      - name: bpfman-operator.vnext
+  # TODO: Uncomment and update when Konflux builds are available.
+  # - schema: olm.bundle
+  #   # This should point to your latest CI-built bundle from Konflux.
+  #   # Update this SHA whenever you want to test a new build.
+  #   image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:latest
+  #   name: bpfman-operator.vnext

--- a/templates/y-stream.yaml
+++ b/templates/y-stream.yaml
@@ -1,0 +1,13 @@
+schema: olm.template.basic
+entries:
+  - schema: olm.package
+    name: bpfman-operator
+    defaultChannel: stable
+  - schema: olm.channel
+    package: bpfman-operator
+    name: stable
+    entries:
+      - name: bpfman-operator.v0.5.7-dev
+  - schema: olm.bundle
+    image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:36922ea0b333bf60bfd358425681c472db07a99dd07c929383ee3bcc5e93c19f
+    name: bpfman-operator.v0.5.7-dev

--- a/templates/z-stream.yaml
+++ b/templates/z-stream.yaml
@@ -1,0 +1,14 @@
+schema: olm.template.basic
+entries:
+  - schema: olm.package
+    name: bpfman-operator
+    defaultChannel: stable
+  - schema: olm.channel
+    package: bpfman-operator
+    name: stable
+    entries:
+      - name: bpfman-operator.v0.5.7-dev
+  - schema: olm.bundle
+    # Z-stream patch releases from Red Hat registry
+    image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:36922ea0b333bf60bfd358425681c472db07a99dd07c929383ee3bcc5e93c19f
+    name: bpfman-operator.v0.5.7-dev


### PR DESCRIPTION
## Summary
- Establishes catalog build infrastructure modelled after netobserv-catalog
- Provides templates for different release streams (dev, y-stream, z-stream)
- Adds automation for generating, building, and deploying OLM catalogs

## Changes
- Added template files for dev, y-stream, and z-stream releases
- Created Makefile with targets for catalog generation and image building
- Added Dockerfile using upstream OPM v1.54.0
- Updated README with comprehensive documentation
- Generated initial catalog from bpfman-operator v0.5.7-dev

## Test Plan
- [x] Catalog generation tested with `make generate`
- [x] Image build tested with `make build-image`
- [x] Deployment tested on local cluster
- [x] CatalogSource verified as READY
- [ ] Integration with Konflux CI/CD (future work)