### PR TITLE
Pass git commit SHA as COMMIT build argument to Dockerfile

### DIFF
--- a/.tekton/build-fbc-pipeline.yaml
+++ b/.tekton/build-fbc-pipeline.yaml
@@ -207,6 +207,7 @@ spec:
     - name: BUILD_ARGS
       value:
       - $(params.build-args[*])
+      - COMMIT=$(tasks.clone-repository.results.commit)
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
     - name: SOURCE_URL


### PR DESCRIPTION
## Summary

Automatically pass the git commit SHA to the Dockerfile build process to populate the `upstream-vcs-ref` label.

## Details

The buildah task already receives the commit SHA from the clone-repository task via the `COMMIT_SHA` parameter. This change adds it to the `BUILD_ARGS` array so it's automatically passed to the Dockerfile as the `COMMIT` build argument.

This ensures the `upstream-vcs-ref` label is populated with the actual git commit SHA for all catalog builds (y-stream, z-stream, dev, etc.) without needing to configure it in each PipelineRun.

## Testing

Tested with PR #5 - the built image shows the correct commit SHA in the `upstream-vcs-ref` label.