### PR TITLE
Update y-stream catalog to latest operator bundle

### DIFF
--- a/templates/y-stream.yaml
+++ b/templates/y-stream.yaml
@@ -9,5 +9,5 @@ entries:
     entries:
       - name: bpfman-operator.v0.5.7-dev
   - schema: olm.bundle
-    image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream@sha256:2306c1855f999b24e812dcaf09d3556150422e1806ad49fc67b180f04075d79f
+    image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream@sha256:910d39b46fd7dc10b250c6e43e1f93b046142830f7e42432708be93f23b2a09b
     name: bpfman-operator.v0.5.7-dev


### PR DESCRIPTION
## Summary

Update the y-stream template to reference the latest operator bundle from September 30, 2025.

## Details

- **Previous bundle**: Built on September 29, 2025 at 09:50:34Z
- **New bundle**: Built on September 30, 2025 at 09:07:10Z
- **Image**: `quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream@sha256:910d39b46fd7dc10b250c6e43e1f93b046142830f7e42432708be93f23b2a09b`

This ensures the catalog references the most recent operator bundle available in the Konflux build system.