### PR TITLE
Update y-stream catalog to latest operator bundle

### DIFF
--- a/auto-generated/catalog/y-stream.yaml
+++ b/auto-generated/catalog/y-stream.yaml
@@ -9,7 +9,7 @@ name: stable
 package: bpfman-operator
 schema: olm.channel
 ---
-image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:36922ea0b333bf60bfd358425681c472db07a99dd07c929383ee3bcc5e93c19f
+image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream@sha256:910d39b46fd7dc10b250c6e43e1f93b046142830f7e42432708be93f23b2a09b
 name: bpfman-operator.v0.5.7-dev
 package: bpfman-operator
 properties:
@@ -1031,8 +1031,8 @@ properties:
         ]
       capabilities: Basic Install
       categories: OpenShift Optional
-      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:7a3c4e3bf315ee004833cbbd4e8847b5520afb056fecbe8019528d1f7ef4abf8
-      createdAt: 04 Aug 2025, 08:10
+      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:15c8308420e8e37233aec3513e46e5910049e477679c7514ed6ca29bf680709a
+      createdAt: 30 Sep 2025, 09:07
       description: The eBPF manager Operator is designed to manage eBPF programs for
         applications.
       features.operators.openshift.io/cnf: "false"
@@ -1098,18 +1098,18 @@ properties:
     description: "The eBPF manager Operator is a Kubernetes Operator for deploying
       [bpfman](https://bpfman.netlify.app/), a system daemon\nfor managing eBPF programs.
       It deploys bpfman itself along with CRDs to make deploying\neBPF programs in
-      Kubernetes much easier.\n\n## Quick Start\n \nTo get bpfman up and running quickly
+      Kubernetes much easier.\n\n## Quick Start\n\nTo get bpfman up and running quickly
       simply click 'install' to deploy the bpfman-operator in the bpfman namespace
       via operator-hub.\n## Configuration\n\nThe `bpfman-config` configmap is automatically
       created in the `bpfman` namespace and used to configure the bpfman deployment.\n\nTo
       edit the config simply run\n\n```bash\nkubectl edit cm bpfman-config\n```\n\nThe
       following fields are adjustable\n\n- `bpfman.agent.image`: The image used for
-      the bpfman-agent`\n- `bpfman.image`: The image used for bpfman`\n - `bpfman.log.level`:
+      the bpfman-agent`\n- `bpfman.image`: The image used for bpfman`\n- `bpfman.log.level`:
       the log level for bpfman, currently supports `debug`, `info`, `warn`, `error`,
       and `fatal`, defaults to `info`\n- `bpfman.agent.log.level`: the log level for
       the bpfman-agent currently supports `info`, `debug`, and `trace` \n\nThe bpfman
       operator deploys eBPF programs via CRDs. The following CRDs are currently available,
-      \n\n- BpfApplication\n- ClusterBpfApplication\n - BpfApplicationState\n - ClusterBpfApplicationState\n\n
+      \n\n- BpfApplication\n- ClusterBpfApplication\n - BpfApplicationState\n- ClusterBpfApplicationState\n\n
       ## More information\n\nPlease checkout the [bpfman community website](https://bpfman.io/)
       for more information."
     displayName: eBPF Manager Operator
@@ -1145,8 +1145,8 @@ properties:
       name: Red Hat
       url: https://www.redhat.com/
 relatedImages:
-- image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:36922ea0b333bf60bfd358425681c472db07a99dd07c929383ee3bcc5e93c19f
+- image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream@sha256:910d39b46fd7dc10b250c6e43e1f93b046142830f7e42432708be93f23b2a09b
   name: ""
-- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:7a3c4e3bf315ee004833cbbd4e8847b5520afb056fecbe8019528d1f7ef4abf8
+- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:15c8308420e8e37233aec3513e46e5910049e477679c7514ed6ca29bf680709a
   name: ""
 schema: olm.bundle

--- a/templates/y-stream.yaml
+++ b/templates/y-stream.yaml
@@ -9,5 +9,5 @@ entries:
     entries:
       - name: bpfman-operator.v0.5.7-dev
   - schema: olm.bundle
-    image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream@sha256:2306c1855f999b24e812dcaf09d3556150422e1806ad49fc67b180f04075d79f
+    image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream@sha256:910d39b46fd7dc10b250c6e43e1f93b046142830f7e42432708be93f23b2a09b
     name: bpfman-operator.v0.5.7-dev


### PR DESCRIPTION
## Summary

Update the y-stream template to reference the latest operator bundle from October 1, 2025.

## Details

- **Previous bundle**: Built on September 29, 2025
- **New bundle**: Built on September 30, 2025 at 09:07:10Z
- **Image**: `quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream@sha256:910d39b46fd7dc10b250c6e43e1f93b046142830f7e42432708be93f23b2a09b`

This ensures the catalog references the most recent operator bundle available in the Konflux build system.