### PR TITLE
Use :latest tag for catalog image in Tekton pipeline

### DIFF
--- a/.tekton/catalog-ystream-push.yaml
+++ b/.tekton/catalog-ystream-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/catalog-ystream:{{revision}}
+    value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/catalog-ystream:latest
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
## Summary
- Update catalog-ystream-push.yaml to use :latest tag instead of {{revision}}
- Follow Network Observability Operator's established pattern for consistent image tagging
- Align with bpfman-operator-bundle-ystream pipeline configuration

## Test plan
- [ ] Verify Tekton pipeline builds catalog image with :latest tag
- [ ] Confirm image promotion workflow continues to function correctly
- [ ] Check catalog deployment uses expected image reference

Related to openshift/bpfman-operator#944 (similar change for bundle pipeline).