### PR TITLE
Disable Go module dependency updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+  ],
+  "labels": ["dependencies"],
+  "gomod": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## Summary

Add renovate.json configuration to disable automatic Go module updates via Renovate/Mintmaker.

This prevents automated bumps of Go dependencies.

## Changes

- Add renovate.json with `gomod.enabled: false`
- Extend from konflux-ci/mintmaker base configuration