### PR TITLE
Add z-stream image mirrors to ImageDigestMirrorSet

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -14,15 +14,19 @@ spec:
     - source: registry.redhat.io/bpfman/bpfman-agent
       mirrors:
         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-agent-ystream
+        - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-agent-zstream
     # Mirror for the bpfman-operator bundle
     - source: registry.redhat.io/bpfman/bpfman-operator-bundle
       mirrors:
         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream
+        - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-zstream
     # Mirror for the bpfman-operator image
     - source: registry.redhat.io/bpfman/bpfman-rhel9-operator
       mirrors:
         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-ystream
+        - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-zstream
     # Mirror for the bpfman daemon image
     - source: registry.redhat.io/bpfman/bpfman
       mirrors:
         - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-daemon-ystream
+        - quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-daemon-zstream


### PR DESCRIPTION
## Summary

Add z-stream equivalents for all bpfman component mirrors to ensure proper image resolution for both y-stream and z-stream builds.

## Changes

- Added z-stream mirrors for `bpfman-agent`
- Added z-stream mirrors for `bpfman-operator-bundle`
- Added z-stream mirrors for `bpfman-operator`
- Added z-stream mirrors for `bpfman-daemon`

The `catalog-zstream` mirror was already present in the configuration. This change adds the corresponding z-stream mirrors for all other components referenced in the catalog bundles, ensuring consistency across all image references.

## Related

See also: https://github.com/openshift/bpfman-operator/pull/982