### PR TITLE
Test: y-stream EC validation with released bundle

### DIFF
--- a/templates/y-stream.yaml
+++ b/templates/y-stream.yaml
@@ -9,5 +9,5 @@ entries:
     entries:
       - name: bpfman-operator.v0.5.7-dev
   - schema: olm.bundle
-    image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:latest
+    image: registry.stage.redhat.io/bpfman/bpfman-operator-bundle@sha256:f755814c47659177cbb3aff7b4e5a1f60b17c46c67fa651ce336c6b9b7cfb7b1
     name: bpfman-operator.v0.5.7-dev


### PR DESCRIPTION
## Purpose

Test to verify that enterprise contract validation passes when the y-stream catalog template uses a released bundle with digest pinning instead of `:latest` tag.

## Changes

Update `templates/y-stream.yaml` to use:
- Registry: `registry.stage.redhat.io` (approved)
- Reference: `@sha256:f755814c...` (digest pinned)

Instead of:
- Registry: `quay.io/redhat-user-workloads/` (not approved for FBC)
- Reference: `:latest` (not allowed by OLM policies)

## Expected Result

If merged and released through `catalog-ystream-staging`, the enterprise contract validation should **pass** because:
1. ✓ Bundle is from an approved registry (`registry.stage.redhat.io`)
2. ✓ Bundle uses digest reference (not a tag)

This proves the EC validation failures are specifically due to the `:latest` + `quay.io/redhat-user-workloads/` combination needed for QE testing workflows.

## Bundle Details

- Digest: `sha256:f755814c47659177cbb3aff7b4e5a1f60b17c46c67fa651ce336c6b9b7cfb7b1`
- From release: `bpfman-ystream-6t56x-b15c9d7-mmblm`
- Advisory: https://access.stage.redhat.com/errata/RHEA-2025:31201

## Next Steps

1. Merge this PR
2. Wait for Konflux to build catalog-ystream
3. Trigger catalog-ystream-staging release
4. Verify EC validation passes
5. Revert this change (QE needs `:latest` for their workflows)