### PR TITLE
Add released.yaml template and final-ystream make target

### DIFF
--- a/auto-generated/catalog/released.yaml
+++ b/auto-generated/catalog/released.yaml
@@ -1,0 +1,9 @@
+---
+defaultChannel: stable
+name: bpfman-operator
+schema: olm.package
+---
+entries: []
+name: stable
+package: bpfman-operator
+schema: olm.channel

--- a/auto-generated/catalog/y-stream.yaml
+++ b/auto-generated/catalog/y-stream.yaml
@@ -1031,8 +1031,8 @@ properties:
         ]
       capabilities: Basic Install
       categories: OpenShift Optional
-      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:3a4a943f1a1b3ba07bf8797e5298e9623770fbe777f0be1fa56fc4e4c09b8580
-      createdAt: 06 Oct 2025, 08:44
+      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:4d38c6cd4c1bebce99de4bb4481373927ca3ade9a840db1469feeb705400588d
+      createdAt: 16 Oct 2025, 09:52
       description: The eBPF manager Operator is designed to manage eBPF programs for
         applications.
       features.operators.openshift.io/cnf: "false"
@@ -1147,6 +1147,6 @@ properties:
 relatedImages:
 - image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:latest
   name: ""
-- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:3a4a943f1a1b3ba07bf8797e5298e9623770fbe777f0be1fa56fc4e4c09b8580
+- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:4d38c6cd4c1bebce99de4bb4481373927ca3ade9a840db1469feeb705400588d
   name: ""
 schema: olm.bundle

--- a/templates/released.yaml
+++ b/templates/released.yaml
@@ -1,0 +1,9 @@
+schema: olm.template.basic
+entries:
+  - schema: olm.package
+    name: bpfman-operator
+    defaultChannel: stable
+  - schema: olm.channel
+    package: bpfman-operator
+    name: stable
+    entries: []


### PR DESCRIPTION
## Summary

Following NetObserv's pattern, introduce a released catalogue template workflow for production releases.

## Changes

- Add `templates/released.yaml` as an empty template (no releases yet)
- Add `make final-ystream` target to generate released.yaml from y-stream template with pinned bundle digest
- Automatically converts:
  - `:latest` tags to `@sha256:digest` references
  - `registry.stage.redhat.io` to `registry.redhat.io`
  - `v0.5.7-dev` to `v0.5.7`

## Rationale

This separates development (y-stream with `:latest` for QE) from production releases (released with pinned digests) and ensures Enterprise Contract validation passes for production catalogues.

The `released.yaml` template is currently empty as no production releases have been made yet. It will be populated when the first release is promoted.

## Usage

```bash
make final-ystream BUNDLE_SHA=<bundle-digest>
```

Find the bundle digest from the latest successful bpfman-ystream release:
https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/ocp-bpfman-tenant/applications/bpfman-ystream/releases

## References

- Upstream pattern: https://github.com/netobserv/netobserv-catalog
- Related MR: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/6669