### PR TITLE
Add CEL path expressions to catalog-ystream pipelines

### DIFF
--- a/.tekton/catalog-ystream-pull-request.yaml
+++ b/.tekton/catalog-ystream-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && (".tekton/***".pathChanged() || "Dockerfile".pathChanged() || "auto-generated/catalog/y-stream.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: catalog-ystream

--- a/.tekton/catalog-ystream-push.yaml
+++ b/.tekton/catalog-ystream-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && (".tekton/***".pathChanged() || "Dockerfile".pathChanged() || "auto-generated/catalog/y-stream.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: catalog-ystream


### PR DESCRIPTION
Add path-based trigger expressions to the catalog-ystream Tekton pipelines following the pattern established by catalog-4-20 and matching the netobserv-catalog approach.

## Changes

The pipelines now only trigger when relevant files change:
- `.tekton/***` (pipeline configuration changes)
- `Dockerfile` (base build file)
- `auto-generated/catalog/y-stream.yaml` (catalog content)

This prevents unnecessary builds when unrelated files change in the repository.

## Pattern consistency

This matches:
- **catalog-4-20** which already has these CEL expressions
- **netobserv-catalog** ystream/zstream pattern (reference: netobserv/netobserv-catalog)