### PR TITLE
Extract CSV metadata from bundle images during analysis

### DIFF
--- a/pkg/analysis/analyser.go
+++ b/pkg/analysis/analyser.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/operator-framework/operator-registry/pkg/containertools"
+	"github.com/operator-framework/operator-registry/pkg/image/execregistry"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,23 +35,23 @@ func AnalyseBundle(ctx context.Context, bundleRefStr string) (*BundleAnalysis, e
 		Images:    []ImageResult{},
 	}
 
-	logrus.Debugf("Extracting bundle metadata")
+	logrus.Infof("Inspecting bundle metadata from %s", bundleRef.String())
 	bundleInfo, err := extractBundleMetadata(ctx, bundleRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract bundle metadata: %w", err)
 	}
 	analysis.BundleInfo = bundleInfo
 
-	logrus.Debugf("Extracting image references from bundle")
+	logrus.Infof("Extracting image references from bundle")
 	imageRefs, err := ExtractImageReferences(ctx, bundleRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract image references: %w", err)
 	}
 
-	logrus.Debugf("Found %d image references", len(imageRefs))
+	logrus.Infof("Found %d image references, inspecting each", len(imageRefs))
 	imageResults := make([]ImageResult, len(imageRefs))
 	for i, ref := range imageRefs {
-		logrus.Debugf("Inspecting image %d/%d: %s", i+1, len(imageRefs), ref)
+		logrus.Infof("Inspecting image %d/%d: %s", i+1, len(imageRefs), ref)
 		result, err := InspectImage(ctx, ref)
 		if err != nil {
 			imageResults[i] = ImageResult{
@@ -71,21 +73,52 @@ func AnalyseBundle(ctx context.Context, bundleRefStr string) (*BundleAnalysis, e
 // extractBundleMetadata extracts metadata from the bundle image
 // itself.
 func extractBundleMetadata(ctx context.Context, bundleRef ImageRef) (*ImageInfo, error) {
-	if info, err := ExtractImageMetadata(ctx, bundleRef); err == nil {
-		return info, nil
+	var activeRef ImageRef = bundleRef
+	info, err := ExtractImageMetadata(ctx, bundleRef)
+	if err != nil {
+		tenantRef, err := bundleRef.ConvertToTenantWorkspace()
+		if err != nil {
+			return nil, fmt.Errorf("bundle not accessible and cannot convert to tenant workspace: %w", err)
+		}
+
+		info, err = ExtractImageMetadata(ctx, tenantRef)
+		if err != nil {
+			return nil, fmt.Errorf("bundle not accessible in any registry: %w", err)
+		}
+		activeRef = tenantRef
 	}
 
-	tenantRef, err := bundleRef.ConvertToTenantWorkspace()
+	// Extract CSV metadata from bundle
+	csvMetadata, err := extractCSVMetadataFromBundle(ctx, activeRef)
 	if err != nil {
-		return nil, fmt.Errorf("bundle not accessible and cannot convert to tenant workspace: %w", err)
-	}
-
-	info, err := ExtractImageMetadata(ctx, tenantRef)
-	if err != nil {
-		return nil, fmt.Errorf("bundle not accessible in any registry: %w", err)
+		logrus.WithError(err).Debugf("failed to extract CSV metadata from bundle")
+	} else if csvMetadata != nil {
+		if csvMetadata.Version != "" {
+			info.CSVVersion = csvMetadata.Version
+		}
+		if csvMetadata.CreatedAt != "" {
+			info.CSVCreatedAt = csvMetadata.CreatedAt
+		}
 	}
 
 	return info, nil
+}
+
+// extractCSVMetadataFromBundle extracts the CSV metadata using a temporary registry.
+func extractCSVMetadataFromBundle(ctx context.Context, bundleRef ImageRef) (*CSVMetadata, error) {
+	logrus.Debugf("Extracting CSV metadata from bundle: %s", bundleRef.String())
+
+	logrus.SetLevel(logrus.WarnLevel)
+	logger := logrus.NewEntry(logrus.New())
+	logger.Logger.SetLevel(logrus.WarnLevel)
+
+	registry, err := execregistry.NewRegistry(containertools.PodmanTool, logger)
+	if err != nil {
+		return nil, fmt.Errorf("creating image registry: %w", err)
+	}
+	defer registry.Destroy()
+
+	return ExtractCSVMetadata(ctx, bundleRef, registry)
 }
 
 // AnalyseConfig holds configuration options for bundle analysis.

--- a/pkg/analysis/formatter.go
+++ b/pkg/analysis/formatter.go
@@ -40,7 +40,13 @@ func formatText(analysis *BundleAnalysis) string {
 			b.WriteString(fmt.Sprintf("  Created: %s\n", analysis.BundleInfo.Created.Format(time.RFC3339)))
 		}
 		if analysis.BundleInfo.Version != "" {
-			b.WriteString(fmt.Sprintf("  Version: %s\n", analysis.BundleInfo.Version))
+			b.WriteString(fmt.Sprintf("  Image version (label): %s\n", analysis.BundleInfo.Version))
+		}
+		if analysis.BundleInfo.CSVVersion != "" {
+			b.WriteString(fmt.Sprintf("  ClusterServiceVersion: %s\n", analysis.BundleInfo.CSVVersion))
+		}
+		if analysis.BundleInfo.CSVCreatedAt != "" {
+			b.WriteString(fmt.Sprintf("  CSV Created: %s\n", analysis.BundleInfo.CSVCreatedAt))
 		}
 		if analysis.BundleInfo.GitCommit != "" && analysis.BundleInfo.GitURL != "" {
 			commitURL := buildCommitURL(analysis.BundleInfo.GitURL, analysis.BundleInfo.GitCommit)
@@ -110,7 +116,7 @@ func formatImageResult(img ImageResult) string {
 			b.WriteString(fmt.Sprintf("    Created: %s\n", img.Info.Created.Format(time.RFC3339)))
 		}
 		if img.Info.Version != "" {
-			b.WriteString(fmt.Sprintf("    Version: %s\n", img.Info.Version))
+			b.WriteString(fmt.Sprintf("    Image version (label): %s\n", img.Info.Version))
 		}
 		if img.Info.GitCommit != "" && img.Info.GitURL != "" {
 			commitURL := buildCommitURL(img.Info.GitURL, img.Info.GitCommit)

--- a/pkg/analysis/types.go
+++ b/pkg/analysis/types.go
@@ -26,13 +26,15 @@ type ImageResult struct {
 
 // ImageInfo holds extracted metadata from image labels and manifest.
 type ImageInfo struct {
-	Created    *time.Time `json:"created,omitempty"`
-	Version    string     `json:"version,omitempty"`
-	GitCommit  string     `json:"git_commit,omitempty"`
-	GitURL     string     `json:"git_url,omitempty"`
-	CommitDate *time.Time `json:"commit_date,omitempty"`
-	PRNumber   int        `json:"pr_number,omitempty"`
-	PRTitle    string     `json:"pr_title,omitempty"`
+	Created      *time.Time `json:"created,omitempty"`
+	Version      string     `json:"version,omitempty"`
+	CSVVersion   string     `json:"csv_version,omitempty"`
+	CSVCreatedAt string     `json:"csv_created_at,omitempty"`
+	GitCommit    string     `json:"git_commit,omitempty"`
+	GitURL       string     `json:"git_url,omitempty"`
+	CommitDate   *time.Time `json:"commit_date,omitempty"`
+	PRNumber     int        `json:"pr_number,omitempty"`
+	PRTitle      string     `json:"pr_title,omitempty"`
 }
 
 // Summary provides aggregate statistics from the analysis.


### PR DESCRIPTION
## Summary

Enhances bundle analysis to extract version and creation date directly from the ClusterServiceVersion manifest within bundle images. This provides more authoritative version information than relying solely on image labels, which may not always reflect the actual CSV spec.version field.

## Context

This complements recent fixes in openshift/bpfman-operator that ensure CSV versions are properly set during bundle builds:
- openshift/bpfman-operator#1007 - Use OPENSHIFT-VERSION to set CSV version in bundle transformations
- openshift/bpfman-operator#1016 - Add OPENSHIFT-VERSION to Tekton pipeline trigger conditions  
- openshift/bpfman-operator#1019 - Complete bundle CSV version transformation and add build-args support

By extracting CSV metadata directly from bundle manifests, we can verify that these build-time transformations are working correctly and that the CSV spec.version matches the intended release version.

## Changes

- Add CSVMetadata extraction that unpacks bundle images to a temporary directory, locates ClusterServiceVersion files in the manifests, and parses the YAML to extract spec.version and metadata.annotations.createdAt fields
- Update ImageInfo to store both image label version and CSV version separately
- Improve logging visibility by changing debug logs to info level during bundle inspection, making it easier to track progress through multiple image references
- Update text formatting to clearly distinguish between version labels and CSV version fields in output