### PR TITLE
Add release definitions for bpfman-operator version 0.5.8

### DIFF
--- a/releases/0.5.8/bpfman.yaml
+++ b/releases/0.5.8/bpfman.yaml
@@ -1,0 +1,13 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: release-bpfman-0-5-8-4
+  namespace: ocp-bpfman-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'frobware'
+spec:
+  releasePlan: bpfman-zstream
+  snapshot: bpfman-zstream-kdnlr
+  data:
+    releaseNotes:
+      type: RHEA

--- a/releases/0.5.8/fbc-4.20.yaml
+++ b/releases/0.5.8/fbc-4.20.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: bpfman-0-5-8-fbc-4-20-0
+  namespace: ocp-bpfman-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'frobware'
+spec:
+  releasePlan: catalog-4-20
+  snapshot: catalog-4-20-wr5rc


### PR DESCRIPTION
## Summary

Add Konflux release manifests for the 0.5.8 release cycle. These manifests enable triggering releases through the Konflux platform.

## Changes

- **releases/0.5.8/bpfman.yaml**: Operator release using bpfman-zstream plan and snapshot kdnlr. This creates the operator release for OpenShift 4.20.

- **releases/0.5.8/fbc-4.20.yaml**: File-based catalog release using catalog-4-20 plan and snapshot wr5rc. This publishes the operator to the OpenShift 4.20 catalog index.

## Usage

These manifests can be applied with:
```bash
oc apply -f releases/0.5.8/bpfman.yaml
oc apply -f releases/0.5.8/fbc-4.20.yaml
```

This will trigger the respective release pipelines in the ocp-bpfman-tenant namespace.

## Related

This follows the release of version 0.5.8 to the catalog in PR #45.