### PR TITLE
Update y-stream catalog to reference bpfman-operator v0.6.0

### DIFF
--- a/auto-generated/catalog/y-stream.yaml
+++ b/auto-generated/catalog/y-stream.yaml
@@ -4,13 +4,13 @@ name: bpfman-operator
 schema: olm.package
 ---
 entries:
-- name: bpfman-operator.v0.5.7-dev
+- name: bpfman-operator.v0.6.0
 name: stable
 package: bpfman-operator
 schema: olm.channel
 ---
 image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:latest
-name: bpfman-operator.v0.5.7-dev
+name: bpfman-operator.v0.6.0
 package: bpfman-operator
 properties:
 - type: olm.gvk
@@ -36,7 +36,7 @@ properties:
 - type: olm.package
   value:
     packageName: bpfman-operator
-    version: 0.5.7-dev
+    version: 0.6.0
 - type: olm.csv.metadata
   value:
     annotations:
@@ -1031,8 +1031,8 @@ properties:
         ]
       capabilities: Basic Install
       categories: OpenShift Optional
-      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:4d38c6cd4c1bebce99de4bb4481373927ca3ade9a840db1469feeb705400588d
-      createdAt: 16 Oct 2025, 09:52
+      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:84ac1c0c09ae89b313a64f0ba7d16ef891d3a17a9f4d56fe0aece3cc21cae591
+      createdAt: 03 Nov 2025, 19:19
       description: The eBPF manager Operator is designed to manage eBPF programs for
         applications.
       features.operators.openshift.io/cnf: "false"
@@ -1147,6 +1147,6 @@ properties:
 relatedImages:
 - image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:latest
   name: ""
-- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:4d38c6cd4c1bebce99de4bb4481373927ca3ade9a840db1469feeb705400588d
+- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:84ac1c0c09ae89b313a64f0ba7d16ef891d3a17a9f4d56fe0aece3cc21cae591
   name: ""
 schema: olm.bundle

--- a/templates/y-stream.yaml
+++ b/templates/y-stream.yaml
@@ -7,7 +7,7 @@ entries:
     package: bpfman-operator
     name: stable
     entries:
-      - name: bpfman-operator.v0.5.7-dev
+      - name: bpfman-operator.v0.6.0
   - schema: olm.bundle
     image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:latest
-    name: bpfman-operator.v0.5.7-dev
+    name: bpfman-operator.v0.6.0


### PR DESCRIPTION
## Summary

Update the y-stream template to reference version 0.6.0 instead of 0.5.7-dev.

This change follows the branch cut for OCP 4.20 / bpfman release 0.5.8 as documented in openshift/bpfman-operator#1121.

Although no upstream changes have been merged yet, this establishes the version baseline for ongoing 0.6-based development work. The generated catalogue remains largely unchanged as the codebase content is currently identical, with only the version number updated.

## Changes

- Updated `templates/y-stream.yaml` to reference `bpfman-operator.v0.6.0`
- Regenerated `auto-generated/catalog/y-stream.yaml` with the new version

## Related

- openshift/bpfman-operator#1121