### PR TITLE
Add catalogue release manifest for bpfman-operator v0.5.9

### DIFF
--- a/releases/0.5.9/fbc-4.20.yaml
+++ b/releases/0.5.9/fbc-4.20.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: bpfman-0-5-9-fbc-4-20-0
+  namespace: ocp-bpfman-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'frobware'
+spec:
+  releasePlan: catalog-4-20
+  snapshot: catalog-4-20-7k5lv


### PR DESCRIPTION
## Summary

Add the catalogue release manifest to complete the v0.5.9 release ledger.

## Changes

- Add `releases/0.5.9/fbc-4.20.yaml` with snapshot `catalog-4-20-7k5lv`

## Release Status

The catalogue release has been applied and completed successfully:
- Release: `bpfman-0-5-9-fbc-4-20-0`
- Plan: `catalog-4-20` (public production)
- Snapshot: `catalog-4-20-7k5lv`
- Status: **Succeeded**

This publishes bpfman-operator v0.5.9 to the OpenShift 4.20 catalogue index for public production use.

## Complete Release Ledger

Version 0.5.9 release manifest ledger:
- Component release: `releases/0.5.9/bpfman.yaml` (committed in PR #53)
  - Snapshot: `bpfman-zstream-nk6d4`
  - Status: Succeeded
- Catalogue release: `releases/0.5.9/fbc-4.20.yaml` (this PR)
  - Snapshot: `catalog-4-20-7k5lv`
  - Status: Succeeded