### PR TITLE
Add snapshot validation tool for Konflux releases

### DIFF
--- a/validate-snapshot.py
+++ b/validate-snapshot.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Validate that a Konflux snapshot is self-consistent for OLM bundle releases.
+
+Checks that all component SHAs referenced inside the bundle (CSV + ConfigMap)
+match the component SHAs actually present in the snapshot.
+"""
+
+import argparse
+import subprocess
+import sys
+import tempfile
+import json
+import re
+
+
+def detect_stream(snapshot_name):
+    """Detect stream (ystream/zstream) from snapshot name."""
+    if "ystream" in snapshot_name:
+        return "ystream"
+    elif "zstream" in snapshot_name:
+        return "zstream"
+    else:
+        raise ValueError(f"Cannot detect stream from snapshot name: {snapshot_name}")
+
+
+def get_snapshot_components(snapshot_name, namespace):
+    """Get component SHAs from snapshot."""
+    cmd = ["oc", "get", "snapshot", "-n", namespace, snapshot_name, "-o", "json"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    snapshot = json.loads(result.stdout)
+
+    stream = detect_stream(snapshot_name)
+    components = {}
+    for comp in snapshot["spec"]["components"]:
+        name = comp["name"]
+        image = comp["containerImage"]
+        sha = image.split("@")[1]
+        components[name] = sha
+
+    return components, stream
+
+
+def extract_bundle_refs(bundle_sha, stream):
+    """Extract component SHAs referenced in bundle CSV and ConfigMap."""
+    bundle_image = f"quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-{stream}@{bundle_sha}"
+
+    # Create temporary container
+    result = subprocess.run(
+        ["podman", "create", bundle_image], capture_output=True, text=True, check=True
+    )
+    container_id = result.stdout.strip()
+
+    try:
+        # Extract CSV
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".yaml") as csv_file:
+            subprocess.run(
+                [
+                    "podman",
+                    "cp",
+                    f"{container_id}:/manifests/bpfman-operator.clusterserviceversion.yaml",
+                    csv_file.name,
+                ],
+                check=True,
+            )
+            csv_content = open(csv_file.name).read()
+
+        # Extract ConfigMap
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".yaml") as cm_file:
+            subprocess.run(
+                [
+                    "podman",
+                    "cp",
+                    f"{container_id}:/manifests/bpfman-config_v1_configmap.yaml",
+                    cm_file.name,
+                ],
+                check=True,
+            )
+            cm_content = open(cm_file.name).read()
+    finally:
+        # Clean up container
+        subprocess.run(["podman", "rm", container_id], check=True, capture_output=True)
+
+    # Parse operator SHA from CSV
+    operator_match = re.search(
+        r"registry\.redhat\.io/bpfman/bpfman-rhel9-operator@(sha256:[a-f0-9]+)",
+        csv_content,
+    )
+    operator_sha = operator_match.group(1) if operator_match else None
+
+    # Parse agent/daemon SHAs from ConfigMap
+    agent_match = re.search(r"bpfman\.agent\.image:.*@(sha256:[a-f0-9]+)", cm_content)
+    agent_sha = agent_match.group(1) if agent_match else None
+
+    daemon_match = re.search(r"bpfman\.image:.*@(sha256:[a-f0-9]+)", cm_content)
+    daemon_sha = daemon_match.group(1) if daemon_match else None
+
+    return {"operator": operator_sha, "agent": agent_sha, "daemon": daemon_sha}
+
+
+def validate_snapshot(snapshot_name, namespace="ocp-bpfman-tenant"):
+    """Validate snapshot self-consistency."""
+    print(f"=== Validating Snapshot: {snapshot_name} ===\n")
+
+    # Get snapshot components
+    components, stream = get_snapshot_components(snapshot_name, namespace)
+
+    print("Snapshot contains:")
+    print(f"  Operator: {components[f'bpfman-operator-{stream}']}")
+    print(f"  Agent:    {components[f'bpfman-agent-{stream}']}")
+    print(f"  Daemon:   {components[f'bpfman-daemon-{stream}']}")
+    print(f"  Bundle:   {components[f'bpfman-operator-bundle-{stream}']}")
+    print()
+
+    # Extract bundle references
+    bundle_sha = components[f"bpfman-operator-bundle-{stream}"]
+    refs = extract_bundle_refs(bundle_sha, stream)
+
+    print("Bundle references:")
+    print(f"  CSV Operator:     {refs['operator']}")
+    print(f"  ConfigMap Agent:  {refs['agent']}")
+    print(f"  ConfigMap Daemon: {refs['daemon']}")
+    print()
+
+    # Compare
+    valid = True
+
+    if refs["operator"] != components[f"bpfman-operator-{stream}"]:
+        print(f"❌ MISMATCH: CSV operator != Snapshot operator")
+        print(f"   Bundle wants:  {refs['operator']}")
+        print(f"   Snapshot has:  {components[f'bpfman-operator-{stream}']}")
+        valid = False
+    else:
+        print("✅ CSV operator matches snapshot")
+
+    if refs["agent"] != components[f"bpfman-agent-{stream}"]:
+        print(f"❌ MISMATCH: ConfigMap agent != Snapshot agent")
+        print(f"   Bundle wants:  {refs['agent']}")
+        print(f"   Snapshot has:  {components[f'bpfman-agent-{stream}']}")
+        valid = False
+    else:
+        print("✅ ConfigMap agent matches snapshot")
+
+    if refs["daemon"] != components[f"bpfman-daemon-{stream}"]:
+        print(f"❌ MISMATCH: ConfigMap daemon != Snapshot daemon")
+        print(f"   Bundle wants:  {refs['daemon']}")
+        print(f"   Snapshot has:  {components[f'bpfman-daemon-{stream}']}")
+        valid = False
+    else:
+        print("✅ ConfigMap daemon matches snapshot")
+
+    print()
+    if valid:
+        print("✅ VALID: This snapshot is self-consistent and safe to release")
+        return 0
+    else:
+        print("❌ INVALID: This snapshot has mismatches")
+        print("   - Will fail Enterprise Contract if operator mismatched")
+        print("   - Will fail in production if agent/daemon mismatched")
+        return 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate Konflux snapshot self-consistency"
+    )
+    parser.add_argument("snapshot", help="Snapshot name to validate")
+    parser.add_argument(
+        "--namespace",
+        "-n",
+        default="ocp-bpfman-tenant",
+        help="Namespace (default: ocp-bpfman-tenant)",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        sys.exit(validate_snapshot(args.snapshot, args.namespace))
+    except subprocess.CalledProcessError as e:
+        print(f"\nError: {e}", file=sys.stderr)
+        sys.exit(2)
+    except Exception as e:
+        print(f"\nUnexpected error: {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add `validate-snapshot.py` to verify that Konflux snapshots are self-consistent before creating releases.

## The Problem

Due to parallel builds and the nudge system in Konflux, **only approximately 7% of snapshots are self-consistent**. A snapshot is self-consistent when the component SHAs embedded inside the bundle (in both the CSV and ConfigMap) match the component SHAs actually present in the snapshot.

### How the Race Condition Occurs

1. Multiple components (agent, daemon, operator) build in parallel
2. Each completion triggers a nudge PR that updates `hack/konflux/images/*.txt` files
3. Multiple operator builds are triggered, each triggering bundle builds
4. Bundle builds freeze component references at build time (reading from .txt files)
5. Snapshot creation selects the latest available build of each component
6. By the time the snapshot is created, the bundle's embedded references may be stale

### Why Enterprise Contract Isn't Sufficient

Enterprise Contract only validates the CSV operator SHA, not the ConfigMap agent/daemon SHAs. Using an invalid snapshot will either:
- **Fail Enterprise Contract** if the operator SHA mismatches (blocks release)
- **Fail in production** if agent/daemon SHAs mismatch (passes EC but fails at runtime)

## Usage

### Validate a single snapshot

```bash
./validate-snapshot.py bpfman-zstream-nk6d4
```

### Example: Valid snapshot

```
=== Validating Snapshot: bpfman-zstream-nk6d4 ===

Snapshot contains:
  Operator: sha256:60d64887fb8b0c2fd13e4bb08fc7a3c84225b4e9f59bf80992d7f3ec6df086ca
  Agent:    sha256:642641e14a86f34c15d97b90029e0d0f558b7e5cf8fc7bf086d2ebfbfe3e5f5e
  Daemon:   sha256:642641e14a86f34c15d97b90029e0d0f558b7e5cf8fc7bf086d2ebfbfe3e5f5e
  Bundle:   sha256:f6177142b9cf34025053d5585054de85d31090126679b4125f5082b1f504e641

Bundle references:
  CSV Operator:     sha256:60d64887fb8b0c2fd13e4bb08fc7a3c84225b4e9f59bf80992d7f3ec6df086ca
  ConfigMap Agent:  sha256:642641e14a86f34c15d97b90029e0d0f558b7e5cf8fc7bf086d2ebfbfe3e5f5e
  ConfigMap Daemon: sha256:642641e14a86f34c15d97b90029e0d0f558b7e5cf8fc7bf086d2ebfbfe3e5f5e

✅ CSV operator matches snapshot
✅ ConfigMap agent matches snapshot
✅ ConfigMap daemon matches snapshot

✅ VALID: This snapshot is self-consistent and safe to release
```

### Example: Invalid snapshot

```
=== Validating Snapshot: bpfman-zstream-b7mrw ===

Snapshot contains:
  Operator: sha256:60d64887fb8b0c2fd13e4bb08fc7a3c84225b4e9f59bf80992d7f3ec6df086ca
  Agent:    sha256:88fa734ac07ee4d8d8adfbbf1f6e1f0d16c1d20ebab8913b1aaba4f4d59a9a0e
  Daemon:   sha256:88fa734ac07ee4d8d8adfbbf1f6e1f0d16c1d20ebab8913b1aaba4f4d59a9a0e
  Bundle:   sha256:0aab9296469786da27c965343c293a4a7f1ec1b445e3badcd5e58ba322ca5958

Bundle references:
  CSV Operator:     sha256:60d64887fb8b0c2fd13e4bb08fc7a3c84225b4e9f59bf80992d7f3ec6df086ca
  ConfigMap Agent:  sha256:642641e14a86f34c15d97b90029e0d0f558b7e5cf8fc7bf086d2ebfbfe3e5f5e
  ConfigMap Daemon: sha256:642641e14a86f34c15d97b90029e0d0f558b7e5cf8fc7bf086d2ebfbfe3e5f5e

✅ CSV operator matches snapshot
❌ MISMATCH: ConfigMap agent != Snapshot agent
   Bundle wants:  sha256:642641e14a86f34c15d97b90029e0d0f558b7e5cf8fc7bf086d2ebfbfe3e5f5e
   Snapshot has:  sha256:88fa734ac07ee4d8d8adfbbf1f6e1f0d16c1d20ebab8913b1aaba4f4d59a9a0e
❌ MISMATCH: ConfigMap daemon != Snapshot daemon
   Bundle wants:  sha256:642641e14a86f34c15d97b90029e0d0f558b7e5cf8fc7bf086d2ebfbfe3e5f5e
   Snapshot has:  sha256:88fa734ac07ee4d8d8adfbbf1f6e1f0d16c1d20ebab8913b1aaba4f4d59a9a0e

❌ INVALID: This snapshot has mismatches
   - Will fail Enterprise Contract if operator mismatched
   - Will fail in production if agent/daemon mismatched
```

### Scan multiple snapshots

```bash
# Find a valid snapshot from today's builds
for snapshot in $(oc get snapshots -n ocp-bpfman-tenant \
  -l appstudio.openshift.io/application=bpfman-zstream \
  --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[*].metadata.name}'); do
  ./validate-snapshot.py $snapshot && break
done
```

## Requirements

- Python 3
- `oc` CLI authenticated to the Konflux cluster
- `podman` for extracting bundle contents
- Access to `ocp-bpfman-tenant` namespace

## Impact

This tool was essential for the 0.5.9 release:
- Scanned 76 snapshots from a single day
- Found only 5 valid snapshots (7% success rate)
- Prevented release failures by identifying invalid snapshots before applying release manifests
- Validated that running cluster pods matched the released snapshot exactly

## Related

This validation requirement is documented in the release process and should be run before every component release.