### PR TITLE
Update catalogue release manifest to use corrected snapshot

### DIFF
--- a/releases/0.5.9/fbc-4.20.yaml
+++ b/releases/0.5.9/fbc-4.20.yaml
@@ -1,10 +1,10 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: bpfman-0-5-9-fbc-4-20-0
+  name: bpfman-0-5-9-fbc-4-20-1
   namespace: ocp-bpfman-tenant
   labels:
     release.appstudio.openshift.io/author: 'frobware'
 spec:
   releasePlan: catalog-4-20
-  snapshot: catalog-4-20-7k5lv
+  snapshot: catalog-4-20-g5nrv


### PR DESCRIPTION
## Summary

Update the fbc-4.20 release manifest for v0.5.9 to use the corrected catalog snapshot that includes the v0.5.9 bundle entry.

## Background

The original release manifest in PR #55 used snapshot `catalog-4-20-7k5lv`, which was created when PR #54 merged. However, PR #54 only updated the template files without regenerating the catalog files, so that snapshot's catalog was missing the v0.5.9 bundle entry.

PR #58 corrected this by regenerating the catalog files, which triggered a new catalog-4-20 pipeline build that created snapshot `catalog-4-20-g5nrv` with the complete catalog.

## Changes

- **Release name**: `bpfman-0-5-9-fbc-4-20-0` → `bpfman-0-5-9-fbc-4-20-1` (incremented)
- **Snapshot**: `catalog-4-20-7k5lv` → `catalog-4-20-g5nrv` (corrected)

## Timeline

1. PR #54: Updated templates but forgot to regenerate catalogs
2. Snapshot `catalog-4-20-7k5lv` created with incomplete catalog
3. PR #55: Created release manifest using bad snapshot
4. PR #58: Regenerated catalogs with v0.5.9 bundle entry
5. Snapshot `catalog-4-20-g5nrv` created with complete catalog
6. **This PR**: Update release manifest to use corrected snapshot

## Verification

The new snapshot contains the complete catalog with:
- bpfman-operator.v0.5.8 (existing)
- bpfman-operator.v0.5.9 (added in PR #58)

Pipeline run: `catalog-4-20-g5nrv-46493c9-h8w42` (Succeeded)

## Related

- #54: Template update (missing catalog regeneration)
- #55: Original release manifest (used incomplete catalog)
- #58: Corrected catalog regeneration