### PR TITLE
Record bpfman-operator v0.5.10 FBC release for OpenShift 4.20

### DIFF
--- a/releases/0.5.10/fbc-4.20.yaml
+++ b/releases/0.5.10/fbc-4.20.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: bpfman-0-5-10-fbc-4-20-2
+  namespace: ocp-bpfman-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'frobware'
+spec:
+  releasePlan: catalog-4-20
+  snapshot: catalog-4-20-kgqmt


### PR DESCRIPTION
## Summary

Record the successful FBC release of bpfman-operator v0.5.10 for OpenShift 4.20 in the releases ledger.

## Details

This adds the release manifest `releases/0.5.10/fbc-4.20.yaml` which documents the FBC release processed by the Konflux release pipeline. The release:

- Uses snapshot: `catalog-4-20-kgqmt`
- References release plan: `catalog-4-20`
- Was processed by pipeline: `managed-zz9tj`
- Duration: 16m36s
- Status: Succeeded

The release pipeline successfully:
- Verified Enterprise Contract compliance
- Built IIB index image for v4.20
- Signed the index image with Cosign
- Published to the target index
- Created Pyxis image entry

This maintains the releases ledger as documented in #57, tracking all FBC releases for audit and operational visibility.

## Related

- Snapshot: catalog-4-20-kgqmt
- Pipeline run: managed-zz9tj (rhtap-releng-tenant)
- Base index: registry-proxy.engineering.redhat.com/rh-osbs/iib-pub:v4.20