### PR TITLE
Enable multi-architecture builds for catalog streams

### DIFF
--- a/.tekton/catalog-4-20-pull-request.yaml
+++ b/.tekton/catalog-4-20-pull-request.yaml
@@ -28,8 +28,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: build-platforms
-    value:
-    - linux/x86_64
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
   - name: dockerfile
     value: Dockerfile
   - name: build-args-file

--- a/.tekton/catalog-4-20-push.yaml
+++ b/.tekton/catalog-4-20-push.yaml
@@ -25,8 +25,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/catalog-4-20:latest
   - name: build-platforms
-    value:
-    - linux/x86_64
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
   - name: dockerfile
     value: Dockerfile
   - name: build-args-file

--- a/.tekton/catalog-ystream-pull-request.yaml
+++ b/.tekton/catalog-ystream-pull-request.yaml
@@ -28,8 +28,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: build-platforms
-    value:
-    - linux/x86_64
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
   - name: dockerfile
     value: Dockerfile
   - name: build-args-file

--- a/.tekton/catalog-ystream-push.yaml
+++ b/.tekton/catalog-ystream-push.yaml
@@ -25,8 +25,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/catalog-ystream:latest
   - name: build-platforms
-    value:
-    - linux/x86_64
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
   - name: dockerfile
     value: Dockerfile
   - name: build-args-file

--- a/.tekton/catalog-zstream-pull-request.yaml
+++ b/.tekton/catalog-zstream-pull-request.yaml
@@ -28,8 +28,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: build-platforms
-    value:
-    - linux/x86_64
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
   - name: dockerfile
     value: Dockerfile
   - name: build-args-file

--- a/.tekton/catalog-zstream-push.yaml
+++ b/.tekton/catalog-zstream-push.yaml
@@ -25,8 +25,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/catalog-zstream:latest
   - name: build-platforms
-    value:
-    - linux/x86_64
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
   - name: dockerfile
     value: Dockerfile
   - name: build-args-file


### PR DESCRIPTION
## Summary

Enable multi-architecture builds for all catalog streams to support ARM and other architectures.

## Changes

- Update all Tekton pipeline configurations to build for linux/x86_64, linux/arm64, linux/ppc64le, and linux/s390x
- Affects catalog-ystream, catalog-zstream, and catalog-4-20 (both push and pull-request pipelines)
- Follows the same pattern as netobserv-catalog

## Problem Solved

This addresses the issue where ARM clusters cannot use the eBPF Manager Operator catalog because the latest tagged catalog images are only built for x86_64. With these changes, the catalog will be available for all supported OpenShift architectures.

## Testing

Once merged, new catalog builds will include multi-arch manifests that can be deployed on ARM clusters for netobserv test cases.