### PR TITLE
Fix y-stream template with complete release history

### DIFF
--- a/auto-generated/catalog/y-stream.yaml
+++ b/auto-generated/catalog/y-stream.yaml
@@ -7,10 +7,3442 @@ name: bpfman-operator
 schema: olm.package
 ---
 entries:
+- name: bpfman-operator.v0.5.8
+- name: bpfman-operator.v0.5.9
+  replaces: bpfman-operator.v0.5.8
+- name: bpfman-operator.v0.5.10
+  replaces: bpfman-operator.v0.5.9
 - name: bpfman-operator.v0.6.0
+  replaces: bpfman-operator.v0.5.10
 name: stable
 package: bpfman-operator
 schema: olm.channel
+---
+image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:f015580da52da53c9fa9e5629804b9ac6b3026208d271f8d7ac0bd55f887bad7
+name: bpfman-operator.v0.5.10
+package: bpfman-operator
+properties:
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: BpfApplication
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: BpfApplicationState
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: ClusterBpfApplication
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: ClusterBpfApplicationState
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bpfman-operator
+    version: 0.5.10
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "BpfApplication",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/name": "bpfapplication"
+              },
+              "name": "bpfapplication-sample",
+              "namespace": "acme"
+            },
+            "spec": {
+              "byteCode": {
+                "image": {
+                  "url": "quay.io/bpfman-bytecode/app-test:latest"
+                }
+              },
+              "globalData": {
+                "GLOBAL_u32": [
+                  13,
+                  12,
+                  11,
+                  10
+                ],
+                "GLOBAL_u8": [
+                  1
+                ]
+              },
+              "nodeSelector": {},
+              "programs": [
+                {
+                  "name": "tc_pass_test",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 55
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "BpfApplicationState",
+            "metadata": {
+              "creationTimestamp": "2025-04-30T20:59:17Z",
+              "finalizers": [
+                "bpfman.io.nsbpfapplicationcontroller/finalizer"
+              ],
+              "generation": 1,
+              "labels": {
+                "bpfman.io/ownedByProgram": "bpfapplication-sample",
+                "kubernetes.io/hostname": "bpfman-deployment-control-plane"
+              },
+              "name": "bpfapplication-sample-ed7beed4",
+              "namespace": "acme",
+              "ownerReferences": [
+                {
+                  "apiVersion": "bpfman.io/v1alpha1",
+                  "blockOwnerDeletion": true,
+                  "controller": true,
+                  "kind": "BpfApplication",
+                  "name": "bpfapplication-sample",
+                  "uid": "a3897014-2014-4585-90a1-ccdb70adeef9"
+                }
+              ],
+              "resourceVersion": "1348",
+              "uid": "5728d3b2-a576-4144-be74-e5c83619344e"
+            },
+            "status": {
+              "appLoadStatus": "LoadSuccess",
+              "conditions": [
+                {
+                  "lastTransitionTime": "2025-04-30T21:01:50Z",
+                  "message": "The BPF application has been successfully loaded and attached",
+                  "reason": "Success",
+                  "status": "True",
+                  "type": "Success"
+                }
+              ],
+              "node": "bpfman-deployment-control-plane",
+              "programs": [
+                {
+                  "name": "tc_pass_test",
+                  "programId": 1398,
+                  "programLinkStatus": "Success",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1909324080,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "38e00746-b7be-4bcf-bf14-622ad349b4fa"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1342701196,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "ba806cdf-5980-4e7f-8d8f-d819e6a57220"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 2698014225,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "e74fa413-d5df-4aa8-8d17-b580b6cb42a5"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 184300305,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "cef8985d-f184-4b18-9ee2-fe21018fae77"
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "programId": 1399,
+                  "programLinkStatus": "Success",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 1256673356,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "3feed40b-fe4b-4a69-8e91-49624df45673"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 18009714,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "37b02539-0884-418d-bee4-31456384495e"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 3446068106,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "24a56373-8967-46f4-bbd4-423a7872f18b"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 733646956,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "4c855178-0a35-4ac6-abf7-83e61541aca4"
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "programId": 1400,
+                  "programLinkStatus": "Success",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containerPid": 3041,
+                        "function": "malloc",
+                        "linkId": 3629930733,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "ed72f8a7-cdc9-4245-8c40-c645fa5969d7"
+                      },
+                      {
+                        "containerPid": 3032,
+                        "function": "malloc",
+                        "linkId": 1860984127,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "5c3b196d-bbe9-4b2c-8c5c-9d78c5ed6512"
+                      },
+                      {
+                        "containerPid": 2792,
+                        "function": "malloc",
+                        "linkId": 3256920823,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "927071d2-c574-4c1f-87f2-baa5e7cfcc8f"
+                      },
+                      {
+                        "containerPid": 2833,
+                        "function": "malloc",
+                        "linkId": 3700254381,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "fd351a1a-fb83-4b6c-af2f-c84906c6b54b"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "programId": 1401,
+                  "programLinkStatus": "Success",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containerPid": 3041,
+                        "function": "malloc",
+                        "linkId": 4161687115,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "2c8ad027-eca0-4da9-baa6-f7b6f0fc25fd"
+                      },
+                      {
+                        "containerPid": 3032,
+                        "function": "malloc",
+                        "linkId": 3445215503,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "623f2642-9f85-45ca-bab4-8f98d8a31079"
+                      },
+                      {
+                        "containerPid": 2792,
+                        "function": "malloc",
+                        "linkId": 1387817990,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "fe81f29b-493d-41a9-b1c7-35733c9ee861"
+                      },
+                      {
+                        "containerPid": 2833,
+                        "function": "malloc",
+                        "linkId": 2271422622,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "d6af1106-2c72-4f7d-9ee9-5c32e59e03b7"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "programId": 1402,
+                  "programLinkStatus": "Success",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1752219747,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "17760ccc-5ca7-4d21-9590-5f6e5c0fd4ab"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 3877814802,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "194d2096-a15f-417f-9be6-2032217f3e86"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 2514284800,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "de0f43b3-6a0e-4c22-8127-9fb519a0238b"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1682543086,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "84289766-bff1-4af5-a0bd-5d150747a29a"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "updateCount": 2
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "ClusterBpfApplication",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/name": "clusterbpfapplication"
+              },
+              "name": "clusterbpfapplication-sample"
+            },
+            "spec": {
+              "byteCode": {
+                "image": {
+                  "url": "quay.io/bpfman-bytecode/app-test:latest"
+                }
+              },
+              "globalData": {
+                "GLOBAL_u32": [
+                  13,
+                  12,
+                  11,
+                  10
+                ],
+                "GLOBAL_u8": [
+                  1
+                ]
+              },
+              "nodeSelector": {},
+              "programs": [
+                {
+                  "kprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "offset": 0
+                      }
+                    ]
+                  },
+                  "name": "kprobe_test",
+                  "type": "KProbe"
+                },
+                {
+                  "kretprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up"
+                      }
+                    ]
+                  },
+                  "name": "kretprobe_test",
+                  "type": "KRetProbe"
+                },
+                {
+                  "name": "tracepoint_test",
+                  "tracepoint": {
+                    "links": [
+                      {
+                        "name": "syscalls/sys_enter_openat"
+                      }
+                    ]
+                  },
+                  "type": "TracePoint"
+                },
+                {
+                  "name": "tc_pass_test",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 55
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 500
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "containerNames": [
+                            "bpfman",
+                            "bpfman-agent"
+                          ],
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "containerNames": [
+                            "bpfman",
+                            "bpfman-agent"
+                          ],
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 55
+                      },
+                      {
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  }
+                },
+                {
+                  "fentry": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "mode": "Attach"
+                      }
+                    ]
+                  },
+                  "name": "fentry_test",
+                  "type": "FEntry"
+                },
+                {
+                  "fexit": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "mode": "Attach"
+                      }
+                    ]
+                  },
+                  "name": "fexit_test",
+                  "type": "FExit"
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "ClusterBpfApplicationState",
+            "metadata": {
+              "creationTimestamp": "2025-04-30T20:58:34Z",
+              "finalizers": [
+                "bpfman.io.clbpfapplicationcontroller/finalizer"
+              ],
+              "generation": 1,
+              "labels": {
+                "bpfman.io/ownedByProgram": "clusterbpfapplication-sample",
+                "kubernetes.io/hostname": "bpfman-deployment-control-plane"
+              },
+              "name": "clusterbpfapplication-sample-d3cc4fee",
+              "ownerReferences": [
+                {
+                  "apiVersion": "bpfman.io/v1alpha1",
+                  "blockOwnerDeletion": true,
+                  "controller": true,
+                  "kind": "ClusterBpfApplication",
+                  "name": "clusterbpfapplication-sample",
+                  "uid": "ab16b9a6-16bd-4a22-98ec-4268efaf8c8d"
+                }
+              ],
+              "resourceVersion": "1176",
+              "uid": "6e7e7446-306f-46ae-98e6-6ff28d9b5bcd"
+            },
+            "status": {
+              "appLoadStatus": "LoadSuccess",
+              "conditions": [
+                {
+                  "lastTransitionTime": "2025-04-30T21:00:16Z",
+                  "message": "The BPF application has been successfully loaded and attached",
+                  "reason": "Success",
+                  "status": "True",
+                  "type": "Success"
+                }
+              ],
+              "node": "bpfman-deployment-control-plane",
+              "programs": [
+                {
+                  "kprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "linkId": 818584239,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "uuid": "3c71185f-8d68-4be8-92cb-32a14a6f118b"
+                      }
+                    ]
+                  },
+                  "name": "kprobe_test",
+                  "programId": 1323,
+                  "programLinkStatus": "Success",
+                  "type": "KProbe"
+                },
+                {
+                  "kretprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "linkId": 3409359936,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "44c75019-f175-4b1e-bb34-d8896e3b0456"
+                      }
+                    ]
+                  },
+                  "name": "kretprobe_test",
+                  "programId": 1324,
+                  "programLinkStatus": "Success",
+                  "type": "KRetProbe"
+                },
+                {
+                  "name": "tracepoint_test",
+                  "programId": 1325,
+                  "programLinkStatus": "Success",
+                  "tracepoint": {
+                    "links": [
+                      {
+                        "linkId": 2625161294,
+                        "linkStatus": "Attached",
+                        "name": "syscalls/sys_enter_openat",
+                        "shouldAttach": true,
+                        "uuid": "40164d8a-5b55-4ff6-8e73-aa53d9180a6d"
+                      }
+                    ]
+                  },
+                  "type": "TracePoint"
+                },
+                {
+                  "name": "tc_pass_test",
+                  "programId": 1327,
+                  "programLinkStatus": "Success",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1304307969,
+                        "linkStatus": "Attached",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "44e6491e-ca98-44a0-b1b7-647b494c84fa"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 1425071644,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "89a05d8f-bb4a-448a-af11-2605d0094b98"
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "programId": 1328,
+                  "programLinkStatus": "Success",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 858546813,
+                        "linkStatus": "Attached",
+                        "priority": 500,
+                        "shouldAttach": true,
+                        "uuid": "6dff4163-4d62-4c93-bc34-739a796ddbb4"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 5042726,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "c066df6a-667e-4382-9e2f-a59f64bc1b7e"
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "programId": 1329,
+                  "programLinkStatus": "Success",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containerPid": 2089,
+                        "function": "malloc",
+                        "linkId": 2687038538,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "e48f1563-f56b-41fa-a87d-b8593fc5faca"
+                      },
+                      {
+                        "containerPid": 2040,
+                        "function": "malloc",
+                        "linkId": 1651822558,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "e0d778df-4791-413b-b0f4-13ed1088500c"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "programId": 1330,
+                  "programLinkStatus": "Success",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containerPid": 2089,
+                        "function": "malloc",
+                        "linkId": 3774838420,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "2f37f466-6ff4-47a1-9c8d-8dd1f97528bb"
+                      },
+                      {
+                        "containerPid": 2040,
+                        "function": "malloc",
+                        "linkId": 1373645282,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "319bbaf0-1c8a-45b4-9d99-5dec27e2e5f1"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "programId": 1332,
+                  "programLinkStatus": "Success",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 4243141192,
+                        "linkStatus": "Attached",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "c3bea5b9-d3e0-4784-9a17-c286b6661fc2"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1465833891,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "1e24df86-f3ff-4e0a-8f20-6759272ddb08"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "fentry": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "linkId": 950386839,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "2eda2367-4540-478b-a40d-cc984475a570"
+                      }
+                    ]
+                  },
+                  "name": "fentry_test",
+                  "programId": 1333,
+                  "programLinkStatus": "Success",
+                  "type": "FEntry"
+                },
+                {
+                  "fexit": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "linkId": 2243237521,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "98910fe0-cad6-457f-8797-9f8200106511"
+                      }
+                    ]
+                  },
+                  "name": "fexit_test",
+                  "programId": 1334,
+                  "programLinkStatus": "Success",
+                  "type": "FExit"
+                }
+              ],
+              "updateCount": 2
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: OpenShift Optional
+      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:d168cb1d5472ca5726aa3621e239005eb3b54d5f5d5d5ffad9a61f95a7c1ed23
+      createdAt: 18 Nov 2025, 14:36
+      description: The eBPF manager Operator is designed to manage eBPF programs for
+        applications.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "true"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: bpfman
+      operatorframework.io/suggested-namespace-template: |-
+        {
+          "apiVersion": "v1",
+          "kind": "Namespace",
+          "metadata": {
+            "name": "bpfman",
+            "labels": {
+              "pod-security.kubernetes.io/enforce": "privileged",
+              "pod-security.kubernetes.io/audit": "privileged",
+              "pod-security.kubernetes.io/warn": "privileged",
+            },
+            "annotations": {
+              "openshift.io/node-selector": ""
+            },
+          }
+        }
+      operators.openshift.io/infrastructure-features: '["csi", "disconnected"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.27.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/bpfman-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: BpfApplication is the Schema for the BpfApplications API
+        displayName: Namespaced Bpf Application
+        kind: BpfApplication
+        name: bpfapplications.bpfman.io
+        version: v1alpha1
+      - description: BpfApplicationState is the Schema for the BpfApplicationState
+          API
+        displayName: Namespaced Bpf Application State
+        kind: BpfApplicationState
+        name: bpfapplicationstates.bpfman.io
+        version: v1alpha1
+      - description: ClusterBpfApplication is the Schema for the clusterbpfapplications
+          API
+        displayName: Cluster Bpf Application
+        kind: ClusterBpfApplication
+        name: clusterbpfapplications.bpfman.io
+        version: v1alpha1
+      - description: ClusterBpfApplicationState is the Schema for the ClusterBpfApplicationState
+          API
+        displayName: Cluster Bpf Application State
+        kind: ClusterBpfApplicationState
+        name: clusterbpfapplicationstates.bpfman.io
+        version: v1alpha1
+    description: "The eBPF manager Operator is a Kubernetes Operator for deploying
+      [bpfman](https://github.com/openshift/bpfman-operator), a system daemon\nfor
+      managing eBPF programs. It deploys bpfman itself along with CRDs to make deploying\neBPF
+      programs in Kubernetes much easier.\n\n## Quick Start\n\nTo get bpfman up and
+      running quickly simply click 'install' to deploy the bpfman-operator in the
+      bpfman namespace via operator-hub.\n## Configuration\n\nThe `bpfman-config`
+      configmap is automatically created in the `bpfman` namespace and used to configure
+      the bpfman deployment.\n\nTo edit the config simply run\n\n```bash\nkubectl
+      edit cm bpfman-config\n```\n\nThe following fields are adjustable\n\n- `bpfman.agent.image`:
+      The image used for the bpfman-agent`\n- `bpfman.image`: The image used for bpfman`\n-
+      `bpfman.log.level`: the log level for bpfman, currently supports `debug`, `info`,
+      `warn`, `error`, and `fatal`, defaults to `info`\n- `bpfman.agent.log.level`:
+      the log level for the bpfman-agent currently supports `info`, `debug`, and `trace`
+      \n\nThe bpfman operator deploys eBPF programs via CRDs. The following CRDs are
+      currently available, \n\n- BpfApplication\n- ClusterBpfApplication\n - BpfApplicationState\n-
+      ClusterBpfApplicationState\n\n ## More information\n\nPlease checkout the [bpfman
+      community website](https://bpfman.io/) for more information."
+    displayName: eBPF Manager Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - ebpf
+    - kubernetes
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: bpfman website
+      url: https://www.redhat.com/
+    maintainers:
+    - email: afredette@redhat.com
+      name: Andre Fredette
+    - email: mmahmoud@redhat.com
+      name: Mohamed Mahmoud
+    maturity: alpha
+    minKubeVersion: 1.26.0
+    provider:
+      name: Red Hat
+      url: https://www.redhat.com/
+relatedImages:
+- image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:f015580da52da53c9fa9e5629804b9ac6b3026208d271f8d7ac0bd55f887bad7
+  name: ""
+- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:d168cb1d5472ca5726aa3621e239005eb3b54d5f5d5d5ffad9a61f95a7c1ed23
+  name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:c186f98463c7afda27f8813a1401901f74c9ffe0414980b1dc04a90e057b5bb0
+name: bpfman-operator.v0.5.8
+package: bpfman-operator
+properties:
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: BpfApplication
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: BpfApplicationState
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: ClusterBpfApplication
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: ClusterBpfApplicationState
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bpfman-operator
+    version: 0.5.8
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "BpfApplication",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/name": "bpfapplication"
+              },
+              "name": "bpfapplication-sample",
+              "namespace": "acme"
+            },
+            "spec": {
+              "byteCode": {
+                "image": {
+                  "url": "quay.io/bpfman-bytecode/app-test:latest"
+                }
+              },
+              "globalData": {
+                "GLOBAL_u32": [
+                  13,
+                  12,
+                  11,
+                  10
+                ],
+                "GLOBAL_u8": [
+                  1
+                ]
+              },
+              "nodeSelector": {},
+              "programs": [
+                {
+                  "name": "tc_pass_test",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 55
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "BpfApplicationState",
+            "metadata": {
+              "creationTimestamp": "2025-04-30T20:59:17Z",
+              "finalizers": [
+                "bpfman.io.nsbpfapplicationcontroller/finalizer"
+              ],
+              "generation": 1,
+              "labels": {
+                "bpfman.io/ownedByProgram": "bpfapplication-sample",
+                "kubernetes.io/hostname": "bpfman-deployment-control-plane"
+              },
+              "name": "bpfapplication-sample-ed7beed4",
+              "namespace": "acme",
+              "ownerReferences": [
+                {
+                  "apiVersion": "bpfman.io/v1alpha1",
+                  "blockOwnerDeletion": true,
+                  "controller": true,
+                  "kind": "BpfApplication",
+                  "name": "bpfapplication-sample",
+                  "uid": "a3897014-2014-4585-90a1-ccdb70adeef9"
+                }
+              ],
+              "resourceVersion": "1348",
+              "uid": "5728d3b2-a576-4144-be74-e5c83619344e"
+            },
+            "status": {
+              "appLoadStatus": "LoadSuccess",
+              "conditions": [
+                {
+                  "lastTransitionTime": "2025-04-30T21:01:50Z",
+                  "message": "The BPF application has been successfully loaded and attached",
+                  "reason": "Success",
+                  "status": "True",
+                  "type": "Success"
+                }
+              ],
+              "node": "bpfman-deployment-control-plane",
+              "programs": [
+                {
+                  "name": "tc_pass_test",
+                  "programId": 1398,
+                  "programLinkStatus": "Success",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1909324080,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "38e00746-b7be-4bcf-bf14-622ad349b4fa"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1342701196,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "ba806cdf-5980-4e7f-8d8f-d819e6a57220"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 2698014225,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "e74fa413-d5df-4aa8-8d17-b580b6cb42a5"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 184300305,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "cef8985d-f184-4b18-9ee2-fe21018fae77"
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "programId": 1399,
+                  "programLinkStatus": "Success",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 1256673356,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "3feed40b-fe4b-4a69-8e91-49624df45673"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 18009714,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "37b02539-0884-418d-bee4-31456384495e"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 3446068106,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "24a56373-8967-46f4-bbd4-423a7872f18b"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 733646956,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "4c855178-0a35-4ac6-abf7-83e61541aca4"
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "programId": 1400,
+                  "programLinkStatus": "Success",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containerPid": 3041,
+                        "function": "malloc",
+                        "linkId": 3629930733,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "ed72f8a7-cdc9-4245-8c40-c645fa5969d7"
+                      },
+                      {
+                        "containerPid": 3032,
+                        "function": "malloc",
+                        "linkId": 1860984127,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "5c3b196d-bbe9-4b2c-8c5c-9d78c5ed6512"
+                      },
+                      {
+                        "containerPid": 2792,
+                        "function": "malloc",
+                        "linkId": 3256920823,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "927071d2-c574-4c1f-87f2-baa5e7cfcc8f"
+                      },
+                      {
+                        "containerPid": 2833,
+                        "function": "malloc",
+                        "linkId": 3700254381,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "fd351a1a-fb83-4b6c-af2f-c84906c6b54b"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "programId": 1401,
+                  "programLinkStatus": "Success",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containerPid": 3041,
+                        "function": "malloc",
+                        "linkId": 4161687115,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "2c8ad027-eca0-4da9-baa6-f7b6f0fc25fd"
+                      },
+                      {
+                        "containerPid": 3032,
+                        "function": "malloc",
+                        "linkId": 3445215503,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "623f2642-9f85-45ca-bab4-8f98d8a31079"
+                      },
+                      {
+                        "containerPid": 2792,
+                        "function": "malloc",
+                        "linkId": 1387817990,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "fe81f29b-493d-41a9-b1c7-35733c9ee861"
+                      },
+                      {
+                        "containerPid": 2833,
+                        "function": "malloc",
+                        "linkId": 2271422622,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "d6af1106-2c72-4f7d-9ee9-5c32e59e03b7"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "programId": 1402,
+                  "programLinkStatus": "Success",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1752219747,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "17760ccc-5ca7-4d21-9590-5f6e5c0fd4ab"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 3877814802,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "194d2096-a15f-417f-9be6-2032217f3e86"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 2514284800,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "de0f43b3-6a0e-4c22-8127-9fb519a0238b"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1682543086,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "84289766-bff1-4af5-a0bd-5d150747a29a"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "updateCount": 2
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "ClusterBpfApplication",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/name": "clusterbpfapplication"
+              },
+              "name": "clusterbpfapplication-sample"
+            },
+            "spec": {
+              "byteCode": {
+                "image": {
+                  "url": "quay.io/bpfman-bytecode/app-test:latest"
+                }
+              },
+              "globalData": {
+                "GLOBAL_u32": [
+                  13,
+                  12,
+                  11,
+                  10
+                ],
+                "GLOBAL_u8": [
+                  1
+                ]
+              },
+              "nodeSelector": {},
+              "programs": [
+                {
+                  "kprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "offset": 0
+                      }
+                    ]
+                  },
+                  "name": "kprobe_test",
+                  "type": "KProbe"
+                },
+                {
+                  "kretprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up"
+                      }
+                    ]
+                  },
+                  "name": "kretprobe_test",
+                  "type": "KRetProbe"
+                },
+                {
+                  "name": "tracepoint_test",
+                  "tracepoint": {
+                    "links": [
+                      {
+                        "name": "syscalls/sys_enter_openat"
+                      }
+                    ]
+                  },
+                  "type": "TracePoint"
+                },
+                {
+                  "name": "tc_pass_test",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 55
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 500
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "containerNames": [
+                            "bpfman",
+                            "bpfman-agent"
+                          ],
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "containerNames": [
+                            "bpfman",
+                            "bpfman-agent"
+                          ],
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 55
+                      },
+                      {
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  }
+                },
+                {
+                  "fentry": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "mode": "Attach"
+                      }
+                    ]
+                  },
+                  "name": "fentry_test",
+                  "type": "FEntry"
+                },
+                {
+                  "fexit": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "mode": "Attach"
+                      }
+                    ]
+                  },
+                  "name": "fexit_test",
+                  "type": "FExit"
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "ClusterBpfApplicationState",
+            "metadata": {
+              "creationTimestamp": "2025-04-30T20:58:34Z",
+              "finalizers": [
+                "bpfman.io.clbpfapplicationcontroller/finalizer"
+              ],
+              "generation": 1,
+              "labels": {
+                "bpfman.io/ownedByProgram": "clusterbpfapplication-sample",
+                "kubernetes.io/hostname": "bpfman-deployment-control-plane"
+              },
+              "name": "clusterbpfapplication-sample-d3cc4fee",
+              "ownerReferences": [
+                {
+                  "apiVersion": "bpfman.io/v1alpha1",
+                  "blockOwnerDeletion": true,
+                  "controller": true,
+                  "kind": "ClusterBpfApplication",
+                  "name": "clusterbpfapplication-sample",
+                  "uid": "ab16b9a6-16bd-4a22-98ec-4268efaf8c8d"
+                }
+              ],
+              "resourceVersion": "1176",
+              "uid": "6e7e7446-306f-46ae-98e6-6ff28d9b5bcd"
+            },
+            "status": {
+              "appLoadStatus": "LoadSuccess",
+              "conditions": [
+                {
+                  "lastTransitionTime": "2025-04-30T21:00:16Z",
+                  "message": "The BPF application has been successfully loaded and attached",
+                  "reason": "Success",
+                  "status": "True",
+                  "type": "Success"
+                }
+              ],
+              "node": "bpfman-deployment-control-plane",
+              "programs": [
+                {
+                  "kprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "linkId": 818584239,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "uuid": "3c71185f-8d68-4be8-92cb-32a14a6f118b"
+                      }
+                    ]
+                  },
+                  "name": "kprobe_test",
+                  "programId": 1323,
+                  "programLinkStatus": "Success",
+                  "type": "KProbe"
+                },
+                {
+                  "kretprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "linkId": 3409359936,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "44c75019-f175-4b1e-bb34-d8896e3b0456"
+                      }
+                    ]
+                  },
+                  "name": "kretprobe_test",
+                  "programId": 1324,
+                  "programLinkStatus": "Success",
+                  "type": "KRetProbe"
+                },
+                {
+                  "name": "tracepoint_test",
+                  "programId": 1325,
+                  "programLinkStatus": "Success",
+                  "tracepoint": {
+                    "links": [
+                      {
+                        "linkId": 2625161294,
+                        "linkStatus": "Attached",
+                        "name": "syscalls/sys_enter_openat",
+                        "shouldAttach": true,
+                        "uuid": "40164d8a-5b55-4ff6-8e73-aa53d9180a6d"
+                      }
+                    ]
+                  },
+                  "type": "TracePoint"
+                },
+                {
+                  "name": "tc_pass_test",
+                  "programId": 1327,
+                  "programLinkStatus": "Success",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1304307969,
+                        "linkStatus": "Attached",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "44e6491e-ca98-44a0-b1b7-647b494c84fa"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 1425071644,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "89a05d8f-bb4a-448a-af11-2605d0094b98"
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "programId": 1328,
+                  "programLinkStatus": "Success",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 858546813,
+                        "linkStatus": "Attached",
+                        "priority": 500,
+                        "shouldAttach": true,
+                        "uuid": "6dff4163-4d62-4c93-bc34-739a796ddbb4"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 5042726,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "c066df6a-667e-4382-9e2f-a59f64bc1b7e"
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "programId": 1329,
+                  "programLinkStatus": "Success",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containerPid": 2089,
+                        "function": "malloc",
+                        "linkId": 2687038538,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "e48f1563-f56b-41fa-a87d-b8593fc5faca"
+                      },
+                      {
+                        "containerPid": 2040,
+                        "function": "malloc",
+                        "linkId": 1651822558,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "e0d778df-4791-413b-b0f4-13ed1088500c"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "programId": 1330,
+                  "programLinkStatus": "Success",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containerPid": 2089,
+                        "function": "malloc",
+                        "linkId": 3774838420,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "2f37f466-6ff4-47a1-9c8d-8dd1f97528bb"
+                      },
+                      {
+                        "containerPid": 2040,
+                        "function": "malloc",
+                        "linkId": 1373645282,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "319bbaf0-1c8a-45b4-9d99-5dec27e2e5f1"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "programId": 1332,
+                  "programLinkStatus": "Success",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 4243141192,
+                        "linkStatus": "Attached",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "c3bea5b9-d3e0-4784-9a17-c286b6661fc2"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1465833891,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "1e24df86-f3ff-4e0a-8f20-6759272ddb08"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "fentry": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "linkId": 950386839,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "2eda2367-4540-478b-a40d-cc984475a570"
+                      }
+                    ]
+                  },
+                  "name": "fentry_test",
+                  "programId": 1333,
+                  "programLinkStatus": "Success",
+                  "type": "FEntry"
+                },
+                {
+                  "fexit": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "linkId": 2243237521,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "98910fe0-cad6-457f-8797-9f8200106511"
+                      }
+                    ]
+                  },
+                  "name": "fexit_test",
+                  "programId": 1334,
+                  "programLinkStatus": "Success",
+                  "type": "FExit"
+                }
+              ],
+              "updateCount": 2
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: OpenShift Optional
+      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:72ee5309a6f23d42019559459326315659df1dd4d4c4101b8f3e6fa2ac043961
+      createdAt: 04 Nov 2025, 08:43
+      description: The eBPF manager Operator is designed to manage eBPF programs for
+        applications.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "true"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: bpfman
+      operatorframework.io/suggested-namespace-template: |-
+        {
+          "apiVersion": "v1",
+          "kind": "Namespace",
+          "metadata": {
+            "name": "bpfman",
+            "labels": {
+              "pod-security.kubernetes.io/enforce": "privileged",
+              "pod-security.kubernetes.io/audit": "privileged",
+              "pod-security.kubernetes.io/warn": "privileged",
+            },
+            "annotations": {
+              "openshift.io/node-selector": ""
+            },
+          }
+        }
+      operators.openshift.io/infrastructure-features: '["csi", "disconnected"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.27.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/bpfman-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: BpfApplication is the Schema for the BpfApplications API
+        displayName: Namespaced Bpf Application
+        kind: BpfApplication
+        name: bpfapplications.bpfman.io
+        version: v1alpha1
+      - description: BpfApplicationState is the Schema for the BpfApplicationState
+          API
+        displayName: Namespaced Bpf Application State
+        kind: BpfApplicationState
+        name: bpfapplicationstates.bpfman.io
+        version: v1alpha1
+      - description: ClusterBpfApplication is the Schema for the clusterbpfapplications
+          API
+        displayName: Cluster Bpf Application
+        kind: ClusterBpfApplication
+        name: clusterbpfapplications.bpfman.io
+        version: v1alpha1
+      - description: ClusterBpfApplicationState is the Schema for the ClusterBpfApplicationState
+          API
+        displayName: Cluster Bpf Application State
+        kind: ClusterBpfApplicationState
+        name: clusterbpfapplicationstates.bpfman.io
+        version: v1alpha1
+    description: "The eBPF manager Operator is a Kubernetes Operator for deploying
+      [bpfman](https://github.com/openshift/bpfman-operator), a system daemon\nfor
+      managing eBPF programs. It deploys bpfman itself along with CRDs to make deploying\neBPF
+      programs in Kubernetes much easier.\n\n## Quick Start\n\nTo get bpfman up and
+      running quickly simply click 'install' to deploy the bpfman-operator in the
+      bpfman namespace via operator-hub.\n## Configuration\n\nThe `bpfman-config`
+      configmap is automatically created in the `bpfman` namespace and used to configure
+      the bpfman deployment.\n\nTo edit the config simply run\n\n```bash\nkubectl
+      edit cm bpfman-config\n```\n\nThe following fields are adjustable\n\n- `bpfman.agent.image`:
+      The image used for the bpfman-agent`\n- `bpfman.image`: The image used for bpfman`\n-
+      `bpfman.log.level`: the log level for bpfman, currently supports `debug`, `info`,
+      `warn`, `error`, and `fatal`, defaults to `info`\n- `bpfman.agent.log.level`:
+      the log level for the bpfman-agent currently supports `info`, `debug`, and `trace`
+      \n\nThe bpfman operator deploys eBPF programs via CRDs. The following CRDs are
+      currently available, \n\n- BpfApplication\n- ClusterBpfApplication\n - BpfApplicationState\n-
+      ClusterBpfApplicationState\n\n ## More information\n\nPlease checkout the [bpfman
+      community website](https://bpfman.io/) for more information."
+    displayName: eBPF Manager Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - ebpf
+    - kubernetes
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: bpfman website
+      url: https://www.redhat.com/
+    maintainers:
+    - email: afredette@redhat.com
+      name: Andre Fredette
+    - email: mmahmoud@redhat.com
+      name: Mohamed Mahmoud
+    maturity: alpha
+    minKubeVersion: 1.26.0
+    provider:
+      name: Red Hat
+      url: https://www.redhat.com/
+relatedImages:
+- image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:c186f98463c7afda27f8813a1401901f74c9ffe0414980b1dc04a90e057b5bb0
+  name: ""
+- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:72ee5309a6f23d42019559459326315659df1dd4d4c4101b8f3e6fa2ac043961
+  name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:f6177142b9cf34025053d5585054de85d31090126679b4125f5082b1f504e641
+name: bpfman-operator.v0.5.9
+package: bpfman-operator
+properties:
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: BpfApplication
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: BpfApplicationState
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: ClusterBpfApplication
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: bpfman.io
+    kind: ClusterBpfApplicationState
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bpfman-operator
+    version: 0.5.9
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "BpfApplication",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/name": "bpfapplication"
+              },
+              "name": "bpfapplication-sample",
+              "namespace": "acme"
+            },
+            "spec": {
+              "byteCode": {
+                "image": {
+                  "url": "quay.io/bpfman-bytecode/app-test:latest"
+                }
+              },
+              "globalData": {
+                "GLOBAL_u32": [
+                  13,
+                  12,
+                  11,
+                  10
+                ],
+                "GLOBAL_u8": [
+                  1
+                ]
+              },
+              "nodeSelector": {},
+              "programs": [
+                {
+                  "name": "tc_pass_test",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 55
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "pods": {
+                            "matchLabels": {
+                              "app": "test-target"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "BpfApplicationState",
+            "metadata": {
+              "creationTimestamp": "2025-04-30T20:59:17Z",
+              "finalizers": [
+                "bpfman.io.nsbpfapplicationcontroller/finalizer"
+              ],
+              "generation": 1,
+              "labels": {
+                "bpfman.io/ownedByProgram": "bpfapplication-sample",
+                "kubernetes.io/hostname": "bpfman-deployment-control-plane"
+              },
+              "name": "bpfapplication-sample-ed7beed4",
+              "namespace": "acme",
+              "ownerReferences": [
+                {
+                  "apiVersion": "bpfman.io/v1alpha1",
+                  "blockOwnerDeletion": true,
+                  "controller": true,
+                  "kind": "BpfApplication",
+                  "name": "bpfapplication-sample",
+                  "uid": "a3897014-2014-4585-90a1-ccdb70adeef9"
+                }
+              ],
+              "resourceVersion": "1348",
+              "uid": "5728d3b2-a576-4144-be74-e5c83619344e"
+            },
+            "status": {
+              "appLoadStatus": "LoadSuccess",
+              "conditions": [
+                {
+                  "lastTransitionTime": "2025-04-30T21:01:50Z",
+                  "message": "The BPF application has been successfully loaded and attached",
+                  "reason": "Success",
+                  "status": "True",
+                  "type": "Success"
+                }
+              ],
+              "node": "bpfman-deployment-control-plane",
+              "programs": [
+                {
+                  "name": "tc_pass_test",
+                  "programId": 1398,
+                  "programLinkStatus": "Success",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1909324080,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "38e00746-b7be-4bcf-bf14-622ad349b4fa"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1342701196,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "ba806cdf-5980-4e7f-8d8f-d819e6a57220"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 2698014225,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "e74fa413-d5df-4aa8-8d17-b580b6cb42a5"
+                      },
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 184300305,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "cef8985d-f184-4b18-9ee2-fe21018fae77"
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "programId": 1399,
+                  "programLinkStatus": "Success",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 1256673356,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "3feed40b-fe4b-4a69-8e91-49624df45673"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 18009714,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "37b02539-0884-418d-bee4-31456384495e"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 3446068106,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "24a56373-8967-46f4-bbd4-423a7872f18b"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 733646956,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "4c855178-0a35-4ac6-abf7-83e61541aca4"
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "programId": 1400,
+                  "programLinkStatus": "Success",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containerPid": 3041,
+                        "function": "malloc",
+                        "linkId": 3629930733,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "ed72f8a7-cdc9-4245-8c40-c645fa5969d7"
+                      },
+                      {
+                        "containerPid": 3032,
+                        "function": "malloc",
+                        "linkId": 1860984127,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "5c3b196d-bbe9-4b2c-8c5c-9d78c5ed6512"
+                      },
+                      {
+                        "containerPid": 2792,
+                        "function": "malloc",
+                        "linkId": 3256920823,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "927071d2-c574-4c1f-87f2-baa5e7cfcc8f"
+                      },
+                      {
+                        "containerPid": 2833,
+                        "function": "malloc",
+                        "linkId": 3700254381,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "fd351a1a-fb83-4b6c-af2f-c84906c6b54b"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "programId": 1401,
+                  "programLinkStatus": "Success",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containerPid": 3041,
+                        "function": "malloc",
+                        "linkId": 4161687115,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "2c8ad027-eca0-4da9-baa6-f7b6f0fc25fd"
+                      },
+                      {
+                        "containerPid": 3032,
+                        "function": "malloc",
+                        "linkId": 3445215503,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "623f2642-9f85-45ca-bab4-8f98d8a31079"
+                      },
+                      {
+                        "containerPid": 2792,
+                        "function": "malloc",
+                        "linkId": 1387817990,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "fe81f29b-493d-41a9-b1c7-35733c9ee861"
+                      },
+                      {
+                        "containerPid": 2833,
+                        "function": "malloc",
+                        "linkId": 2271422622,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "d6af1106-2c72-4f7d-9ee9-5c32e59e03b7"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "programId": 1402,
+                  "programLinkStatus": "Success",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1752219747,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3041/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "17760ccc-5ca7-4d21-9590-5f6e5c0fd4ab"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 3877814802,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/3032/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "194d2096-a15f-417f-9be6-2032217f3e86"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 2514284800,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2792/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "de0f43b3-6a0e-4c22-8127-9fb519a0238b"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1682543086,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2833/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "84289766-bff1-4af5-a0bd-5d150747a29a"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "updateCount": 2
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "ClusterBpfApplication",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/name": "clusterbpfapplication"
+              },
+              "name": "clusterbpfapplication-sample"
+            },
+            "spec": {
+              "byteCode": {
+                "image": {
+                  "url": "quay.io/bpfman-bytecode/app-test:latest"
+                }
+              },
+              "globalData": {
+                "GLOBAL_u32": [
+                  13,
+                  12,
+                  11,
+                  10
+                ],
+                "GLOBAL_u8": [
+                  1
+                ]
+              },
+              "nodeSelector": {},
+              "programs": [
+                {
+                  "kprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "offset": 0
+                      }
+                    ]
+                  },
+                  "name": "kprobe_test",
+                  "type": "KProbe"
+                },
+                {
+                  "kretprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up"
+                      }
+                    ]
+                  },
+                  "name": "kretprobe_test",
+                  "type": "KRetProbe"
+                },
+                {
+                  "name": "tracepoint_test",
+                  "tracepoint": {
+                    "links": [
+                      {
+                        "name": "syscalls/sys_enter_openat"
+                      }
+                    ]
+                  },
+                  "type": "TracePoint"
+                },
+                {
+                  "name": "tc_pass_test",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 55
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 500
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "containerNames": [
+                            "bpfman",
+                            "bpfman-agent"
+                          ],
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containers": {
+                          "containerNames": [
+                            "bpfman",
+                            "bpfman-agent"
+                          ],
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "function": "malloc",
+                        "target": "libc"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceSelector": {
+                          "primaryNodeInterface": true
+                        },
+                        "priority": 55
+                      },
+                      {
+                        "interfaceSelector": {
+                          "interfaces": [
+                            "eth0"
+                          ]
+                        },
+                        "networkNamespaces": {
+                          "namespace": "bpfman",
+                          "pods": {
+                            "matchLabels": {
+                              "name": "bpfman-daemon"
+                            }
+                          }
+                        },
+                        "priority": 100
+                      }
+                    ]
+                  }
+                },
+                {
+                  "fentry": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "mode": "Attach"
+                      }
+                    ]
+                  },
+                  "name": "fentry_test",
+                  "type": "FEntry"
+                },
+                {
+                  "fexit": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "mode": "Attach"
+                      }
+                    ]
+                  },
+                  "name": "fexit_test",
+                  "type": "FExit"
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "bpfman.io/v1alpha1",
+            "kind": "ClusterBpfApplicationState",
+            "metadata": {
+              "creationTimestamp": "2025-04-30T20:58:34Z",
+              "finalizers": [
+                "bpfman.io.clbpfapplicationcontroller/finalizer"
+              ],
+              "generation": 1,
+              "labels": {
+                "bpfman.io/ownedByProgram": "clusterbpfapplication-sample",
+                "kubernetes.io/hostname": "bpfman-deployment-control-plane"
+              },
+              "name": "clusterbpfapplication-sample-d3cc4fee",
+              "ownerReferences": [
+                {
+                  "apiVersion": "bpfman.io/v1alpha1",
+                  "blockOwnerDeletion": true,
+                  "controller": true,
+                  "kind": "ClusterBpfApplication",
+                  "name": "clusterbpfapplication-sample",
+                  "uid": "ab16b9a6-16bd-4a22-98ec-4268efaf8c8d"
+                }
+              ],
+              "resourceVersion": "1176",
+              "uid": "6e7e7446-306f-46ae-98e6-6ff28d9b5bcd"
+            },
+            "status": {
+              "appLoadStatus": "LoadSuccess",
+              "conditions": [
+                {
+                  "lastTransitionTime": "2025-04-30T21:00:16Z",
+                  "message": "The BPF application has been successfully loaded and attached",
+                  "reason": "Success",
+                  "status": "True",
+                  "type": "Success"
+                }
+              ],
+              "node": "bpfman-deployment-control-plane",
+              "programs": [
+                {
+                  "kprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "linkId": 818584239,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "uuid": "3c71185f-8d68-4be8-92cb-32a14a6f118b"
+                      }
+                    ]
+                  },
+                  "name": "kprobe_test",
+                  "programId": 1323,
+                  "programLinkStatus": "Success",
+                  "type": "KProbe"
+                },
+                {
+                  "kretprobe": {
+                    "links": [
+                      {
+                        "function": "try_to_wake_up",
+                        "linkId": 3409359936,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "44c75019-f175-4b1e-bb34-d8896e3b0456"
+                      }
+                    ]
+                  },
+                  "name": "kretprobe_test",
+                  "programId": 1324,
+                  "programLinkStatus": "Success",
+                  "type": "KRetProbe"
+                },
+                {
+                  "name": "tracepoint_test",
+                  "programId": 1325,
+                  "programLinkStatus": "Success",
+                  "tracepoint": {
+                    "links": [
+                      {
+                        "linkId": 2625161294,
+                        "linkStatus": "Attached",
+                        "name": "syscalls/sys_enter_openat",
+                        "shouldAttach": true,
+                        "uuid": "40164d8a-5b55-4ff6-8e73-aa53d9180a6d"
+                      }
+                    ]
+                  },
+                  "type": "TracePoint"
+                },
+                {
+                  "name": "tc_pass_test",
+                  "programId": 1327,
+                  "programLinkStatus": "Success",
+                  "tc": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 1304307969,
+                        "linkStatus": "Attached",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "44e6491e-ca98-44a0-b1b7-647b494c84fa"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 1425071644,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pipe",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "89a05d8f-bb4a-448a-af11-2605d0094b98"
+                      }
+                    ]
+                  },
+                  "type": "TC"
+                },
+                {
+                  "name": "tcx_next_test",
+                  "programId": 1328,
+                  "programLinkStatus": "Success",
+                  "tcx": {
+                    "links": [
+                      {
+                        "direction": "Ingress",
+                        "interfaceName": "eth0",
+                        "linkId": 858546813,
+                        "linkStatus": "Attached",
+                        "priority": 500,
+                        "shouldAttach": true,
+                        "uuid": "6dff4163-4d62-4c93-bc34-739a796ddbb4"
+                      },
+                      {
+                        "direction": "Egress",
+                        "interfaceName": "eth0",
+                        "linkId": 5042726,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "shouldAttach": true,
+                        "uuid": "c066df6a-667e-4382-9e2f-a59f64bc1b7e"
+                      }
+                    ]
+                  },
+                  "type": "TCX"
+                },
+                {
+                  "name": "uprobe_test",
+                  "programId": 1329,
+                  "programLinkStatus": "Success",
+                  "type": "UProbe",
+                  "uprobe": {
+                    "links": [
+                      {
+                        "containerPid": 2089,
+                        "function": "malloc",
+                        "linkId": 2687038538,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "e48f1563-f56b-41fa-a87d-b8593fc5faca"
+                      },
+                      {
+                        "containerPid": 2040,
+                        "function": "malloc",
+                        "linkId": 1651822558,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "e0d778df-4791-413b-b0f4-13ed1088500c"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "uretprobe_test",
+                  "programId": 1330,
+                  "programLinkStatus": "Success",
+                  "type": "URetProbe",
+                  "uretprobe": {
+                    "links": [
+                      {
+                        "containerPid": 2089,
+                        "function": "malloc",
+                        "linkId": 3774838420,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "2f37f466-6ff4-47a1-9c8d-8dd1f97528bb"
+                      },
+                      {
+                        "containerPid": 2040,
+                        "function": "malloc",
+                        "linkId": 1373645282,
+                        "linkStatus": "Attached",
+                        "offset": 0,
+                        "shouldAttach": true,
+                        "target": "libc",
+                        "uuid": "319bbaf0-1c8a-45b4-9d99-5dec27e2e5f1"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "xdp_pass_test",
+                  "programId": 1332,
+                  "programLinkStatus": "Success",
+                  "type": "XDP",
+                  "xdp": {
+                    "links": [
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 4243141192,
+                        "linkStatus": "Attached",
+                        "priority": 55,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "c3bea5b9-d3e0-4784-9a17-c286b6661fc2"
+                      },
+                      {
+                        "interfaceName": "eth0",
+                        "linkId": 1465833891,
+                        "linkStatus": "Attached",
+                        "netnsPath": "/host/proc/2196/ns/net",
+                        "priority": 100,
+                        "proceedOn": [
+                          "Pass",
+                          "DispatcherReturn"
+                        ],
+                        "shouldAttach": true,
+                        "uuid": "1e24df86-f3ff-4e0a-8f20-6759272ddb08"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "fentry": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "linkId": 950386839,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "2eda2367-4540-478b-a40d-cc984475a570"
+                      }
+                    ]
+                  },
+                  "name": "fentry_test",
+                  "programId": 1333,
+                  "programLinkStatus": "Success",
+                  "type": "FEntry"
+                },
+                {
+                  "fexit": {
+                    "function": "do_unlinkat",
+                    "links": [
+                      {
+                        "linkId": 2243237521,
+                        "linkStatus": "Attached",
+                        "shouldAttach": true,
+                        "uuid": "98910fe0-cad6-457f-8797-9f8200106511"
+                      }
+                    ]
+                  },
+                  "name": "fexit_test",
+                  "programId": 1334,
+                  "programLinkStatus": "Success",
+                  "type": "FExit"
+                }
+              ],
+              "updateCount": 2
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: OpenShift Optional
+      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:a0566620789ff5e9727e7436250730b6d00f975030bd62c1dcec258bb7860f35
+      createdAt: 17 Nov 2025, 10:10
+      description: The eBPF manager Operator is designed to manage eBPF programs for
+        applications.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "true"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: bpfman
+      operatorframework.io/suggested-namespace-template: |-
+        {
+          "apiVersion": "v1",
+          "kind": "Namespace",
+          "metadata": {
+            "name": "bpfman",
+            "labels": {
+              "pod-security.kubernetes.io/enforce": "privileged",
+              "pod-security.kubernetes.io/audit": "privileged",
+              "pod-security.kubernetes.io/warn": "privileged",
+            },
+            "annotations": {
+              "openshift.io/node-selector": ""
+            },
+          }
+        }
+      operators.openshift.io/infrastructure-features: '["csi", "disconnected"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.27.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/bpfman-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: BpfApplication is the Schema for the BpfApplications API
+        displayName: Namespaced Bpf Application
+        kind: BpfApplication
+        name: bpfapplications.bpfman.io
+        version: v1alpha1
+      - description: BpfApplicationState is the Schema for the BpfApplicationState
+          API
+        displayName: Namespaced Bpf Application State
+        kind: BpfApplicationState
+        name: bpfapplicationstates.bpfman.io
+        version: v1alpha1
+      - description: ClusterBpfApplication is the Schema for the clusterbpfapplications
+          API
+        displayName: Cluster Bpf Application
+        kind: ClusterBpfApplication
+        name: clusterbpfapplications.bpfman.io
+        version: v1alpha1
+      - description: ClusterBpfApplicationState is the Schema for the ClusterBpfApplicationState
+          API
+        displayName: Cluster Bpf Application State
+        kind: ClusterBpfApplicationState
+        name: clusterbpfapplicationstates.bpfman.io
+        version: v1alpha1
+    description: "The eBPF manager Operator is a Kubernetes Operator for deploying
+      [bpfman](https://github.com/openshift/bpfman-operator), a system daemon\nfor
+      managing eBPF programs. It deploys bpfman itself along with CRDs to make deploying\neBPF
+      programs in Kubernetes much easier.\n\n## Quick Start\n\nTo get bpfman up and
+      running quickly simply click 'install' to deploy the bpfman-operator in the
+      bpfman namespace via operator-hub.\n## Configuration\n\nThe `bpfman-config`
+      configmap is automatically created in the `bpfman` namespace and used to configure
+      the bpfman deployment.\n\nTo edit the config simply run\n\n```bash\nkubectl
+      edit cm bpfman-config\n```\n\nThe following fields are adjustable\n\n- `bpfman.agent.image`:
+      The image used for the bpfman-agent`\n- `bpfman.image`: The image used for bpfman`\n-
+      `bpfman.log.level`: the log level for bpfman, currently supports `debug`, `info`,
+      `warn`, `error`, and `fatal`, defaults to `info`\n- `bpfman.agent.log.level`:
+      the log level for the bpfman-agent currently supports `info`, `debug`, and `trace`
+      \n\nThe bpfman operator deploys eBPF programs via CRDs. The following CRDs are
+      currently available, \n\n- BpfApplication\n- ClusterBpfApplication\n - BpfApplicationState\n-
+      ClusterBpfApplicationState\n\n ## More information\n\nPlease checkout the [bpfman
+      community website](https://bpfman.io/) for more information."
+    displayName: eBPF Manager Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - ebpf
+    - kubernetes
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: bpfman website
+      url: https://www.redhat.com/
+    maintainers:
+    - email: afredette@redhat.com
+      name: Andre Fredette
+    - email: mmahmoud@redhat.com
+      name: Mohamed Mahmoud
+    maturity: alpha
+    minKubeVersion: 1.26.0
+    provider:
+      name: Red Hat
+      url: https://www.redhat.com/
+relatedImages:
+- image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:f6177142b9cf34025053d5585054de85d31090126679b4125f5082b1f504e641
+  name: ""
+- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:a0566620789ff5e9727e7436250730b6d00f975030bd62c1dcec258bb7860f35
+  name: ""
+schema: olm.bundle
 ---
 image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:latest
 name: bpfman-operator.v0.6.0
@@ -1034,8 +4466,8 @@ properties:
         ]
       capabilities: Basic Install
       categories: OpenShift Optional
-      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:84ac1c0c09ae89b313a64f0ba7d16ef891d3a17a9f4d56fe0aece3cc21cae591
-      createdAt: 03 Nov 2025, 19:19
+      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:312a0246b3b2c94ce59a4faaeb69c2926a1664eb300241d5b6e09efbd73ffd64
+      createdAt: 17 Dec 2025, 11:33
       description: The eBPF manager Operator is designed to manage eBPF programs for
         applications.
       features.operators.openshift.io/cnf: "false"
@@ -1150,6 +4582,6 @@ properties:
 relatedImages:
 - image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:latest
   name: ""
-- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:84ac1c0c09ae89b313a64f0ba7d16ef891d3a17a9f4d56fe0aece3cc21cae591
+- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:312a0246b3b2c94ce59a4faaeb69c2926a1664eb300241d5b6e09efbd73ffd64
   name: ""
 schema: olm.bundle

--- a/templates/y-stream.yaml
+++ b/templates/y-stream.yaml
@@ -11,7 +11,22 @@ entries:
     package: bpfman-operator
     name: stable
     entries:
+      - name: bpfman-operator.v0.5.8
+      - name: bpfman-operator.v0.5.9
+        replaces: bpfman-operator.v0.5.8
+      - name: bpfman-operator.v0.5.10
+        replaces: bpfman-operator.v0.5.9
       - name: bpfman-operator.v0.6.0
-  - schema: olm.bundle
+        replaces: bpfman-operator.v0.5.10
+  - schema: olm.bundle          # 0.5.8
+    image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:c186f98463c7afda27f8813a1401901f74c9ffe0414980b1dc04a90e057b5bb0
+    name: bpfman-operator.v0.5.8
+  - schema: olm.bundle          # 0.5.9
+    image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:f6177142b9cf34025053d5585054de85d31090126679b4125f5082b1f504e641
+    name: bpfman-operator.v0.5.9
+  - schema: olm.bundle          # 0.5.10
+    image: registry.redhat.io/bpfman/bpfman-operator-bundle@sha256:f015580da52da53c9fa9e5629804b9ac6b3026208d271f8d7ac0bd55f887bad7
+    name: bpfman-operator.v0.5.10
+  - schema: olm.bundle          # 0.6.0
     image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:latest
     name: bpfman-operator.v0.6.0


### PR DESCRIPTION
## Summary

Fix the y-stream template by adding all prior releases with proper version chain and registry.redhat.io SHAs, following the netobserv-catalog pattern.

## Changes

- **Complete version chain**: v0.5.8 → v0.5.9 → v0.5.10 → v0.6.0
- **Released versions**: Use registry.redhat.io SHAs for stability and multi-arch support
- **Development version**: v0.6.0 uses :latest tag for continuous integration  
- **Regenerated catalog**: Updated auto-generated/catalog/y-stream.yaml with all bundle metadata

## Problem Solved

The current y-stream template only has a single v0.6.0 entry, which breaks OLM's upgrade path resolution and contributes to y-stream release failures. This template provides the complete release history that OLM requires.

## Pattern Alignment

This follows exactly the same pattern as netobserv-catalog:
- Historical releases with pinned registry.redhat.io SHAs
- Latest development version with :latest tag
- Complete upgrade path for OLM resolution

## Testing

- ✅ Template validates with OPM
- ✅ Generated catalog includes all bundle metadata
- ✅ Multi-arch support via existing pipeline changes
- ✅ No formal v0.6.0 release needed (:latest handles development)

The :latest tag approach means we get continuous multi-arch development builds without needing to cut formal releases until ready.