### PR TITLE
bpfman-catalog: Add operator image override for testing PR-built operators

### DIFF
--- a/cmd/bpfman-catalog/main.go
+++ b/cmd/bpfman-catalog/main.go
@@ -45,9 +45,10 @@ type CLI struct {
 
 // PrepareCatalogBuildFromBundleCmd prepares catalog build artefacts from a bundle image.
 type PrepareCatalogBuildFromBundleCmd struct {
-	BundleImage string `arg:"" required:"" help:"Bundle image reference"`
-	OutputDir   string `default:"${default_artefacts_dir}" help:"Output directory for generated artefacts"`
-	OpmBin      string `type:"path" help:"Path to opm binary for external rendering (uses library by default)"`
+	BundleImage   string `arg:"" required:"" help:"Bundle image reference"`
+	OutputDir     string `default:"${default_artefacts_dir}" help:"Output directory for generated artefacts"`
+	OpmBin        string `type:"path" help:"Path to opm binary for external rendering (uses library by default)"`
+	OperatorImage string `help:"Override operator image (generates post-install patch)"`
 }
 
 // PrepareCatalogBuildFromYAMLCmd prepares catalog build artefacts from existing catalog.yaml.
@@ -85,9 +86,9 @@ func (r *PrepareCatalogBuildFromBundleCmd) Run(globals *GlobalContext) error {
 
 	var gen *bundle.Generator
 	if r.OpmBin != "" {
-		gen = bundle.NewGeneratorWithOmp(r.BundleImage, "preview", r.OpmBin)
+		gen = bundle.NewGeneratorWithOmp(r.BundleImage, "preview", r.OpmBin, r.OperatorImage)
 	} else {
-		gen = bundle.NewGenerator(r.BundleImage, "preview")
+		gen = bundle.NewGenerator(r.BundleImage, "preview", r.OperatorImage)
 	}
 
 	artefacts, err := gen.Generate(globals.Context)
@@ -158,7 +159,7 @@ func (r *PrepareCatalogBuildFromYAMLCmd) Run(globals *GlobalContext) error {
 
 	imageUUID, randomTTL := bundle.GenerateImageUUIDAndTTL()
 
-	makefile := bundle.GenerateMakefile("from-yaml", execPath, imageUUID, randomTTL)
+	makefile := bundle.GenerateMakefile("from-yaml", execPath, imageUUID, randomTTL, "")
 	if err := w.WriteSingle("Makefile", []byte(makefile)); err != nil {
 		return fmt.Errorf("writing Makefile: %w", err)
 	}

--- a/pkg/bundle/fbc.go
+++ b/pkg/bundle/fbc.go
@@ -322,7 +322,7 @@ func getUsernameOrDefault() string {
 
 // GenerateMakefile generates a Makefile for building and deploying
 // the catalog.
-func GenerateMakefile(bundleImage, binaryPath, imageUUID, randomTTL string) string {
+func GenerateMakefile(bundleImage, binaryPath, imageUUID, randomTTL, operatorImageOverride string) string {
 	digestSuffix := extractDigestSuffix(bundleImage)
 
 	localTag := "bpfman-catalog"
@@ -336,19 +336,21 @@ func GenerateMakefile(bundleImage, binaryPath, imageUUID, randomTTL string) stri
 	}
 
 	data := struct {
-		BundleImage string
-		LocalTag    string
-		BinaryPath  string
-		ImageUUID   string
-		RandomTTL   string
-		Username    string
+		BundleImage           string
+		LocalTag              string
+		BinaryPath            string
+		ImageUUID             string
+		RandomTTL             string
+		Username              string
+		OperatorImageOverride string
 	}{
-		BundleImage: bundleImage,
-		LocalTag:    localTag,
-		BinaryPath:  binaryPath,
-		ImageUUID:   imageUUID,
-		RandomTTL:   randomTTL,
-		Username:    getUsernameOrDefault(),
+		BundleImage:           bundleImage,
+		LocalTag:              localTag,
+		BinaryPath:            binaryPath,
+		ImageUUID:             imageUUID,
+		RandomTTL:             randomTTL,
+		Username:              getUsernameOrDefault(),
+		OperatorImageOverride: operatorImageOverride,
 	}
 
 	var buf bytes.Buffer

--- a/pkg/bundle/generator.go
+++ b/pkg/bundle/generator.go
@@ -18,32 +18,34 @@ type Artefacts struct {
 
 // Generator handles bundle to catalog conversion.
 type Generator struct {
-	bundleImage string
-	channel     string
-	ompBinPath  string // Optional path to external opm binary
+	bundleImage           string
+	channel               string
+	ompBinPath            string // Optional path to external opm binary
+	operatorImageOverride string // Optional operator image override
 }
 
 // NewGenerator creates a new bundle generator.
-func NewGenerator(bundleImage, channel string) *Generator {
+func NewGenerator(bundleImage, channel, operatorImageOverride string) *Generator {
 	if channel == "" {
 		channel = "preview"
 	}
 	return &Generator{
-		bundleImage: bundleImage,
-		channel:     channel,
+		bundleImage:           bundleImage,
+		channel:               channel,
+		operatorImageOverride: operatorImageOverride,
 	}
 }
 
-// NewGeneratorWithOmp NewGeneratorWithOpm creates a new bundle generator with external
-// opm binary.
-func NewGeneratorWithOmp(bundleImage, channel, ompBinPath string) *Generator {
+// NewGeneratorWithOmp creates a new bundle generator with external opm binary.
+func NewGeneratorWithOmp(bundleImage, channel, ompBinPath, operatorImageOverride string) *Generator {
 	if channel == "" {
 		channel = "preview"
 	}
 	return &Generator{
-		bundleImage: bundleImage,
-		channel:     channel,
-		ompBinPath:  ompBinPath,
+		bundleImage:           bundleImage,
+		channel:               channel,
+		ompBinPath:            ompBinPath,
+		operatorImageOverride: operatorImageOverride,
 	}
 }
 
@@ -66,7 +68,7 @@ func (g *Generator) Generate(ctx context.Context) (*Artefacts, error) {
 	artefacts := &Artefacts{
 		FBCTemplate: string(fbcYAML),
 		Dockerfile:  GenerateCatalogDockerfile(),
-		Makefile:    GenerateMakefile(g.bundleImage, execPath, imageUUID, randomTTL),
+		Makefile:    GenerateMakefile(g.bundleImage, execPath, imageUUID, randomTTL, g.operatorImageOverride),
 	}
 
 	catalogYAML, err := g.renderCatalog(ctx, fbcTemplate)

--- a/pkg/bundle/templates/Makefile.tmpl
+++ b/pkg/bundle/templates/Makefile.tmpl
@@ -42,6 +42,29 @@ build-and-deploy-catalog: build-catalog-image push-catalog-image deploy-catalog
 subscribe: deploy-catalog
 	@echo "Adding subscription for automatic operator installation..."
 	kubectl apply -f ./manifests/subscription/
+{{if .OperatorImageOverride}}
+
+# Operator image override: {{.OperatorImageOverride}}
+.PHONY: patch-operator
+patch-operator:
+	@echo "Waiting for operator deployment to be ready..."
+	@until kubectl get deployment bpfman-operator -n bpfman 2>/dev/null; do \
+		echo "Waiting for bpfman-operator deployment..."; \
+		sleep 5; \
+	done
+	kubectl wait --for=condition=available deployment/bpfman-operator -n bpfman --timeout=120s
+	@echo "Removing OLM ownership to prevent reconciliation..."
+	kubectl patch deployment bpfman-operator -n bpfman --type=json -p='[{"op": "remove", "path": "/metadata/ownerReferences"}]' 2>/dev/null || true
+	@echo "Patching operator deployment to use image: {{.OperatorImageOverride}}"
+	kubectl set image deployment/bpfman-operator -n bpfman bpfman-operator={{.OperatorImageOverride}}
+	@echo "Waiting for rollout..."
+	kubectl rollout status deployment/bpfman-operator -n bpfman --timeout=120s
+	@echo "Operator image patched successfully."
+	kubectl get pods -n bpfman -o wide | grep bpfman-operator
+
+.PHONY: subscribe-and-patch
+subscribe-and-patch: subscribe patch-operator
+{{end}}
 
 .PHONY: check
 check:
@@ -72,6 +95,10 @@ help:
 	@echo "  deploy-catalog           - Deploy catalog infrastructure only (need to build/push first)"
 	@echo "  build-and-deploy-catalog - Build, push, and deploy catalog infrastructure only"
 	@echo "  subscribe                - Add subscription for automatic installation (requires existing catalog)"
+{{- if .OperatorImageOverride}}
+	@echo "  patch-operator           - Patch operator deployment to use override image"
+	@echo "  subscribe-and-patch      - Subscribe and patch operator image in one step"
+{{- end}}
 	@echo "  check                    - Check status of deployed catalog and operator resources"
 	@echo "  undeploy                 - Remove catalog from cluster"
 	@echo "  all                      - Complete build -> push -> deploy catalog + subscription pipeline"


### PR DESCRIPTION
## Summary

When testing Konflux PR builds, the bundle references production operator images rather than the PR-built operator. This makes it impossible to test operator changes without modifying the bundle source.

This PR adds an `--operator-image` flag to `prepare-catalog-build-from-bundle` that generates a `patch-operator` Makefile target. This target:

1. Removes OLM ownership from the deployment (preventing reconciliation back to the CSV-specified image)
2. Patches the operator deployment to use the specified override image

## Context

This was developed to enable testing of https://github.com/openshift/bpfman-operator/pull/1369, which changes the CSI node driver registrar image from upstream to Red Hat's registry.

## Example Workflow

Generate catalogue artefacts with an operator image override:

```bash
./bin/bpfman-catalog prepare-catalog-build-from-bundle \
    quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream:d4b84a799aea8f69658161526cc08b51b028b9dd \
    --operator-image quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-ystream@sha256:76d67efe53c981b7f1bb1c68220239b1dc2499d61adba5253d24c6b1bc2c963d
```

Build, push, and deploy the catalogue:

```bash
make -C auto-generated/artefacts IMAGE=ttl.sh/my-catalog:30m all
```

Patch the operator deployment to use the PR-built image:

```bash
make -C auto-generated/artefacts patch-operator
```

This patches the operator, which then reconciles the DaemonSet with the new CSI driver image (or whatever changes the PR introduces).

## Verification

Before patching:
```
node-driver-registrar: quay.io/bpfman/csi-node-driver-registrar:v2.13.0
```

After patching:
```
node-driver-registrar: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9:v4.20
```