### PR TITLE
Parameterise OPM container version via the Makefile

### DIFF
--- a/Dockerfile.generate-catalog
+++ b/Dockerfile.generate-catalog
@@ -1,8 +1,12 @@
+# OPM container image version. When invoked via the Makefile, this default is overridden by OPM_CONTAINER_VERSION; bumping only the line below will be ignored by make builds.
+ARG OPM_VERSION=v1.69.0
+
 # Use alpine for the build stage with shell support.
 FROM alpine:latest AS builder
+ARG OPM_VERSION
 
 # Install OPM from the official image.
-COPY --from=quay.io/operator-framework/opm:v1.68.0 /bin/opm /bin/opm
+COPY --from=quay.io/operator-framework/opm:${OPM_VERSION} /bin/opm /bin/opm
 
 # Create containers policy configuration. Use standard development policy
 # that matches Fedora's default configuration.

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ export CGO_ENABLED := 0
 
 # Tool versions (for dependency scanning).
 # OPM_VERSION: for local go install (v1.53+ has go install issues, keep at v1.52.0)
-# OPM_CONTAINER_VERSION: for container image in Dockerfile.generate-catalog (can be newer)
+# OPM_CONTAINER_VERSION: passed as a build-arg to Dockerfile.generate-catalog (see the OPM_VERSION ARG there); this Makefile is the single source of truth for the container OPM version.
 OPM_VERSION := v1.52.0
-OPM_CONTAINER_VERSION := v1.60.0
+OPM_CONTAINER_VERSION := v1.69.0
 YQ_VERSION  := v4.35.2
 
 # Pattern rule: install Go tools.
@@ -36,9 +36,6 @@ TOOL_PKG_opm := github.com/operator-framework/operator-registry/cmd/opm
 TOOL_VERSION_opm := $(OPM_VERSION)
 TOOL_PKG_yq := github.com/mikefarah/yq/v4
 TOOL_VERSION_yq := $(YQ_VERSION)
-
-# OPM image for container-based catalog generation.
-OPM_IMAGE := quay.io/operator-framework/opm:$(OPM_CONTAINER_VERSION)
 
 OPM_BIN ?= $(LOCALBIN)/opm
 YQ_BIN  ?= $(LOCALBIN)/yq
@@ -87,6 +84,7 @@ generate-catalogs-container: | auto-generated/catalog ## Generate catalogs using
 		podman build --quiet \
 			--secret id=dockerconfig,src=$${XDG_RUNTIME_DIR}/containers/auth.json \
 			--build-arg TEMPLATE_FILE=$$template_name \
+			--build-arg OPM_VERSION=$(OPM_CONTAINER_VERSION) \
 			-f Dockerfile.generate-catalog -t bpfman-catalog-cli-temp:$$template_name . && \
 		podman create --name bpfman-catalog-cli-temp-$$template_name bpfman-catalog-cli-temp:$$template_name >/dev/null && \
 		podman cp bpfman-catalog-cli-temp-$$template_name:/catalog.yaml $$catalog && \


### PR DESCRIPTION
This PR supersedes #109. It moves the OPM image version out of `Dockerfile.generate-catalog` and into the Makefile as the single source of truth, and adopts the v1.68.0 -> v1.69.0 bump that Renovate proposed in #109 as part of the same change.

The Dockerfile previously hard-coded the OPM image tag in `Dockerfile.generate-catalog`, so Renovate/MintMaker has been opening a fresh PR for every minor-version bump (most recently #109, v1.68.0 -> v1.69.0; before that #106 brought us to v1.68.0; #103 to v1.67.0; and so on). This change moves the version into `OPM_CONTAINER_VERSION` in the Makefile and wires it through to the Dockerfile via an `ARG OPM_VERSION` build-arg, so the Makefile is the single source of truth for the version used by `make generate-catalogs-container`. The Dockerfile retains a default (v1.69.0, matching the Makefile value) purely as a fallback for direct `podman build` invocations outside `make`; under normal use the Makefile value overrides it, and there is a short comment in the Dockerfile flagging the footgun that bumping only the Dockerfile literal would be silently ignored by `make`.

Worth being explicit about why we maintain two OPM versions and why the container-based path is *complementary* rather than a replacement. The canonical catalog generation path is `make generate-catalogs`, which uses a locally-`go install`-ed OPM pinned to `OPM_VERSION := v1.52.0`. That pin is deliberate: per the commit history (commit 7c221da, "Refactor tool installation and rename Dockerfile for clarity"), v1.53+ has `go install` issues, and v1.52.0 is the last version we can install locally; it is the version that has been confirmed to produce the catalogs we currently ship. The container path (`make generate-catalogs-container`, driven by `Dockerfile.generate-catalog` and `OPM_CONTAINER_VERSION`, now v1.69.0) exists alongside it so that we can exercise newer OPM releases without needing to install them locally, and so that we can verify a newer OPM produces byte-identical catalog output to the v1.52.0 baseline. Treating the two values as a deliberate pair, with the Makefile as the explicit owner of both, makes that intent visible instead of buried in a comment.

The pre-existing `OPM_CONTAINER_VERSION := v1.60.0` was unused and had drifted from the literal `v1.68.0` in the Dockerfile; both are now reconciled and the branch settles at v1.69.0. The dead `OPM_IMAGE := ...` variable, defined alongside it but never read anywhere, is removed.

Renovate's auto-bump behaviour is intentionally untouched here. After this lands, MintMaker's dockerfile manager will simply re-target the `ARG OPM_VERSION=v1.69.0` line instead of the previous `COPY --from=` literal -- the dockerfile manager follows `ARG` defaults referenced in `FROM`/`COPY --from=` -- so future v1.70+ PRs will continue to arrive against the new line. Disabling those auto-bumps is a separate `renovate.json`/MintMaker config change that can be done as a follow-up if we want; this PR is purely the structural move plus the proposed bump.

## Test plan

- Built `Dockerfile.generate-catalog` with the default ARG; verified the resulting layer contains `opm v1.69.0` (matching the Makefile value).
- Verified the `--build-arg OPM_VERSION=...` override flow with an alternate version; the resulting layer contained the overridden version's `opm`. This is the same mechanism the Makefile uses to push `OPM_CONTAINER_VERSION` through to the build.
- Ran the parity check the complementary path is built for: `make generate-catalogs` against local OPM v1.52.0, then `make generate-catalogs-container` against the v1.69.0 container, saving each output and diffing. The two outputs are **byte-identical** (`diff -r` returns no differences across `released.yaml`, `y-stream.yaml`, `z-stream.yaml`). Adopting v1.69.0 in the container path produces the same catalogs as the v1.52.0 baseline.
- Both fresh outputs differ from the currently-checked-in `auto-generated/catalog/y-stream.yaml` by the same 19 lines, but the difference is unrelated to OPM: the `quay.io/redhat-user-workloads/.../bpfman-operator-bundle-ystream:latest` floating tag in `templates/y-stream.yaml` now resolves to bundle `v0.7.0` (digest `e2cf4d9f0e7a...`), whereas the checked-in catalog was generated when it pointed at `v0.6.0` (digest `f4f462bd394b...`). That is a Konflux bundle-release lag, not an OPM behavioural change, and is outside the scope of this PR.