### PR TITLE
Add Tekton pipeline files for catalog-4-22

### DIFF
--- a/.tekton/catalog-4-22-pull-request.yaml
+++ b/.tekton/catalog-4-22-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-catalog?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && (".tekton/***".pathChanged() || "Dockerfile".pathChanged() || "templates/released.Dockerfile-args".pathChanged() || "auto-generated/catalog/released.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: catalog-4-22
+    appstudio.openshift.io/component: catalog-4-22
+    pipelines.appstudio.openshift.io/type: build
+  name: catalog-4-22-on-pull-request
+  namespace: ocp-bpfman-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/catalog-4-22:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+  - name: dockerfile
+    value: Dockerfile
+  - name: build-args-file
+    value: templates/released.Dockerfile-args
+  - name: build-args
+    value:
+    - "BASE_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22"
+    - "INDEX_FILE=./auto-generated/catalog/released.yaml"
+  - name: opm-image
+    value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
+  - name: index-file
+    value: ./auto-generated/catalog/released.yaml
+  pipelineRef:
+    name: build-fbc-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-catalog-4-22
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/catalog-4-22-push.yaml
+++ b/.tekton/catalog-4-22-push.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-catalog?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && (".tekton/***".pathChanged() || "Dockerfile".pathChanged() || "templates/released.Dockerfile-args".pathChanged() || "auto-generated/catalog/released.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: catalog-4-22
+    appstudio.openshift.io/component: catalog-4-22
+    pipelines.appstudio.openshift.io/type: build
+  name: catalog-4-22-on-push
+  namespace: ocp-bpfman-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/catalog-4-22:latest
+  - name: build-platforms
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+  - name: dockerfile
+    value: Dockerfile
+  - name: build-args-file
+    value: templates/released.Dockerfile-args
+  - name: build-args
+    value:
+    - "BASE_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22"
+    - "INDEX_FILE=./auto-generated/catalog/released.yaml"
+  - name: opm-image
+    value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
+  - name: index-file
+    value: ./auto-generated/catalog/released.yaml
+  pipelineRef:
+    name: build-fbc-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-catalog-4-22
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary

- Replace the Konflux-bootstrapped inline `pipelineSpec` (from #111) with `pipelineRef` to `build-fbc-pipeline`, matching the pattern established for `catalog-4-21` in #90.
- Key customizations over the Konflux defaults:
  - Use `pipelineRef: build-fbc-pipeline` instead of inline pipeline spec
  - Add path-change filters to CEL expressions
  - Enable multi-arch builds (x86_64, arm64, ppc64le, s390x)
  - Set `build-args` and `opm-image` to v4.22 base images
  - Set push output-image tag to `latest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configurations to automate builds and releases for the catalog component on pull requests and push events.
  * Added automated image build-and-publish workflows with multi-architecture support, configurable build arguments, run cancellation/retention behavior, and authenticated access to the repository for secure builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->