### PR TITLE
BPFMAN-26: Add FBC 4.22 Release CR for bpfman 0.6.0

### DIFF
--- a/releases/0.6.0/fbc-4.22.yaml
+++ b/releases/0.6.0/fbc-4.22.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: bpfman-0-6-0-fbc-4-22-0
+  namespace: ocp-bpfman-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'alebedev87'
+spec:
+  releasePlan: catalog-4-22
+  snapshot: catalog-4-22-20260601-074909-000


### PR DESCRIPTION
## Summary

- Adds `releases/0.6.0/fbc-4.22.yaml` Release CR targeting the `catalog-4-22` release plan with snapshot `catalog-4-22-20260601-074909-000`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added release configuration for bpfman version 0.6.0 with updated catalog resources and snapshot versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->