### PR TITLE
Add customized catalog-4-18 and catalog-4-19 pipeline files

### DIFF
--- a/.tekton/catalog-4-18-pull-request.yaml
+++ b/.tekton/catalog-4-18-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-catalog?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && (".tekton/***".pathChanged() || "Dockerfile".pathChanged() || "templates/released.Dockerfile-args".pathChanged() || "auto-generated/catalog/released.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: catalog-4-18
+    appstudio.openshift.io/component: catalog-4-18
+    pipelines.appstudio.openshift.io/type: build
+  name: catalog-4-18-on-pull-request
+  namespace: ocp-bpfman-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/catalog-4-18:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+  - name: dockerfile
+    value: Dockerfile
+  - name: build-args-file
+    value: templates/released.Dockerfile-args
+  - name: build-args
+    value:
+    - "BASE_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18"
+    - "INDEX_FILE=./auto-generated/catalog/released.yaml"
+  - name: opm-image
+    value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
+  - name: index-file
+    value: ./auto-generated/catalog/released.yaml
+  pipelineRef:
+    name: build-fbc-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-catalog-4-18
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/catalog-4-18-push.yaml
+++ b/.tekton/catalog-4-18-push.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-catalog?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && (".tekton/***".pathChanged() || "Dockerfile".pathChanged() || "templates/released.Dockerfile-args".pathChanged() || "auto-generated/catalog/released.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: catalog-4-18
+    appstudio.openshift.io/component: catalog-4-18
+    pipelines.appstudio.openshift.io/type: build
+  name: catalog-4-18-on-push
+  namespace: ocp-bpfman-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/catalog-4-18:latest
+  - name: build-platforms
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+  - name: dockerfile
+    value: Dockerfile
+  - name: build-args-file
+    value: templates/released.Dockerfile-args
+  - name: build-args
+    value:
+    - "BASE_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18"
+    - "INDEX_FILE=./auto-generated/catalog/released.yaml"
+  - name: opm-image
+    value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
+  - name: index-file
+    value: ./auto-generated/catalog/released.yaml
+  pipelineRef:
+    name: build-fbc-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-catalog-4-18
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/catalog-4-19-pull-request.yaml
+++ b/.tekton/catalog-4-19-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-catalog?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && (".tekton/***".pathChanged() || "Dockerfile".pathChanged() || "templates/released.Dockerfile-args".pathChanged() || "auto-generated/catalog/released.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: catalog-4-19
+    appstudio.openshift.io/component: catalog-4-19
+    pipelines.appstudio.openshift.io/type: build
+  name: catalog-4-19-on-pull-request
+  namespace: ocp-bpfman-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/catalog-4-19:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+  - name: dockerfile
+    value: Dockerfile
+  - name: build-args-file
+    value: templates/released.Dockerfile-args
+  - name: build-args
+    value:
+    - "BASE_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19"
+    - "INDEX_FILE=./auto-generated/catalog/released.yaml"
+  - name: opm-image
+    value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
+  - name: index-file
+    value: ./auto-generated/catalog/released.yaml
+  pipelineRef:
+    name: build-fbc-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-catalog-4-19
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/catalog-4-19-push.yaml
+++ b/.tekton/catalog-4-19-push.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman-catalog?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && (".tekton/***".pathChanged() || "Dockerfile".pathChanged() || "templates/released.Dockerfile-args".pathChanged() || "auto-generated/catalog/released.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: catalog-4-19
+    appstudio.openshift.io/component: catalog-4-19
+    pipelines.appstudio.openshift.io/type: build
+  name: catalog-4-19-on-push
+  namespace: ocp-bpfman-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ocp-bpfman-tenant/catalog-4-19:latest
+  - name: build-platforms
+    value: ["linux/x86_64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+  - name: dockerfile
+    value: Dockerfile
+  - name: build-args-file
+    value: templates/released.Dockerfile-args
+  - name: build-args
+    value:
+    - "BASE_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19"
+    - "INDEX_FILE=./auto-generated/catalog/released.yaml"
+  - name: opm-image
+    value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
+  - name: index-file
+    value: ./auto-generated/catalog/released.yaml
+  pipelineRef:
+    name: build-fbc-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-catalog-4-19
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary

- Add customized `catalog-4-18` and `catalog-4-19` Tekton pipeline files, replacing the Konflux-generated defaults (PRs #116 and #117) which were failing.
- Replace the inline `pipelineSpec` with `pipelineRef: build-fbc-pipeline` and add version-specific params (`build-args`, `opm-image`, `index-file`, `build-args-file`) matching the pattern established by `catalog-4-20`, `catalog-4-21`, and `catalog-4-22` pipelines.
- Use `registry.redhat.io/openshift4/ose-operator-registry-rhel9` as the base image (same as 4.22), with the appropriate version tags (`v4.18`, `v4.19`).