### PR TITLE
Add `0.6.0` release manifests for 4.18, 4.19, 4.20 catalogs

### DIFF
--- a/releases/0.6.0/fbc-4.18.yaml
+++ b/releases/0.6.0/fbc-4.18.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: bpfman-fbc-4-18-20260604-145954
+  namespace: ocp-bpfman-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'alebedev87'
+spec:
+  releasePlan: catalog-4-18
+  snapshot: catalog-4-18-20260604-145954-000

--- a/releases/0.6.0/fbc-4.19.yaml
+++ b/releases/0.6.0/fbc-4.19.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: bpfman-fbc-4-19-20260604-151316
+  namespace: ocp-bpfman-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'alebedev87'
+spec:
+  releasePlan: catalog-4-19
+  snapshot: catalog-4-19-20260604-151316-000

--- a/releases/0.6.0/fbc-4.20.yaml
+++ b/releases/0.6.0/fbc-4.20.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: bpfman-fbc-4-20-20260604-150237
+  namespace: ocp-bpfman-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'alebedev87'
+spec:
+  releasePlan: catalog-4-20
+  snapshot: catalog-4-20-20260604-150237-000


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added release configurations for catalog versions 4.18, 4.19, and 4.20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->