### PR TITLE
[TEST] Pin y-stream catalog to bpfman-operator-bundle-ystream for Go rewrite testing

### DIFF
--- a/auto-generated/catalog/y-stream.yaml
+++ b/auto-generated/catalog/y-stream.yaml
@@ -12,7 +12,7 @@ name: stable
 package: bpfman-operator
 schema: olm.channel
 ---
-image: registry.stage.redhat.io/bpfman/bpfman-operator-bundle:latest
+image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream@sha256:a1f75c5c117f53856d195d2eb44dfac26f172f250024b85fce785bbf5fb405a2
 name: bpfman-operator.v0.7.0
 package: bpfman-operator
 properties:
@@ -1059,8 +1059,8 @@ properties:
         ]
       capabilities: Basic Install
       categories: OpenShift Optional
-      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:694501796b0dfaefbdf1f1b1571ae48e57acda02d3a38609a1b55c8d2b006ff5
-      createdAt: 29 Jun 2026, 18:12
+      containerImage: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:e5cccd1a10c4c1b9881fed5c99de90b58dcf4d997f040c3261a9938237848517
+      createdAt: 20 Jul 2026, 16:35
       description: The eBPF manager Operator is designed to manage eBPF programs for
         applications.
       features.operators.openshift.io/cnf: "false"
@@ -1175,14 +1175,14 @@ properties:
       name: Red Hat
       url: https://www.redhat.com/
 relatedImages:
-- image: registry.redhat.io/bpfman/bpfman-agent@sha256:c14e8add10661d5893e566733d7bf21108bf8a3ddd4cf552c6810c5b9690de01
-  name: bpfman-agent
-- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:694501796b0dfaefbdf1f1b1571ae48e57acda02d3a38609a1b55c8d2b006ff5
-  name: bpfman-operator
-- image: registry.redhat.io/bpfman/bpfman@sha256:3d938345a90f29e63f9a396e12be151a7d9ddbee640b9d0612af2673b99f7e81
+- image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-daemon-ystream@sha256:d203d9be8fa0d475103ff62d3ac381be32ba4f4c39c14b2fc45495d6437807ac
   name: bpfman
+- image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream@sha256:a1f75c5c117f53856d195d2eb44dfac26f172f250024b85fce785bbf5fb405a2
+  name: ""
+- image: registry.redhat.io/bpfman/bpfman-agent@sha256:14e1ef93d0eaa517b557050fe113353ae53c12e66a7ace1f6a7ceaaa5b9e2465
+  name: bpfman-agent
+- image: registry.redhat.io/bpfman/bpfman-rhel9-operator@sha256:e5cccd1a10c4c1b9881fed5c99de90b58dcf4d997f040c3261a9938237848517
+  name: bpfman-operator
 - image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:c4a2626cc9c4903a32e67a6fa68b874fb5e67085126030389a8a3210bf766de7
   name: csi-node-driver-registrar
-- image: registry.stage.redhat.io/bpfman/bpfman-operator-bundle:latest
-  name: ""
 schema: olm.bundle

--- a/templates/y-stream.yaml
+++ b/templates/y-stream.yaml
@@ -13,5 +13,5 @@ entries:
     entries:
       - name: bpfman-operator.v0.7.0
   - schema: olm.bundle          # 0.7.0
-    image: registry.stage.redhat.io/bpfman/bpfman-operator-bundle:latest
+    image: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator-bundle-ystream@sha256:a1f75c5c117f53856d195d2eb44dfac26f172f250024b85fce785bbf5fb405a2
     name: bpfman-operator.v0.7.0


### PR DESCRIPTION
## Summary

- Replaces the floating `registry.stage.redhat.io/bpfman/bpfman-operator-bundle:latest` reference in the y-stream catalog with a pinned Konflux bundle digest.
- Only `templates/y-stream.yaml` and `auto-generated/catalog/y-stream.yaml` are changed; z-stream and released catalogs are untouched.
- This PR tests the bpfman Go rewrite against the OpenShift test suite using bundle `bpfman-operator-bundle-ystream@sha256:a1f75c5c117f53856d195d2eb44dfac26f172f250024b85fce785bbf5fb405a2`.

Bundle PR: https://github.com/openshift/bpfman-operator/pull/2105.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the operator bundle and container image references to newer Y-stream versions.
  * Replaced mutable image tags with immutable, digest-pinned references for more consistent deployments.
  * Refreshed related image references and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->